### PR TITLE
Add source map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "microdash": "~1",
     "phpcommon": "~1",
+    "source-map": "^0.5.6",
+    "source-map-to-comment": "^1.1.0",
     "transpiler": "~1.2"
   },
   "devDependencies": {

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -687,7 +687,7 @@ module.exports = {
                 initializerCodeChunks = interpret(node.initializer, subContext),
                 updateCodeChunks = interpret(node.update, subContext);
 
-            if (conditionCodeChunks) {
+            if (conditionCodeChunks.length > 0) {
                 conditionCodeChunks.push('.coerceToBoolean().getNative()');
             }
 
@@ -1175,9 +1175,20 @@ module.exports = {
                     buildingSourceMap: !!node.offset,
                     // Define optimized SourceNode factory, depending on mode
                     createSourceNode: node.offset ? function (chunks, node, name) {
+                        if (chunks.length === 0) {
+                            // Allow detecting empty comma expressions etc. by returning an empty array
+                            // rather than an array containing an empty SourceNode
+                            return [];
+                        }
+
                         // Lines are 1-based, but columns are 0-based
                         return [new SourceNode(node.offset.line, node.offset.column - 1, filePath, chunks, name)];
                     } : function (chunks) {
+                        if (chunks.length === 0) {
+                            // See above
+                            return [];
+                        }
+
                         return [new SourceNode(null, null, filePath, chunks)];
                     },
                     labelRepository: new LabelRepository()

--- a/test/integration/transpiler/expressions/magicConstant/classTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/classTest.js
@@ -44,7 +44,10 @@ describe('Transpiler __CLASS__ magic constant test', function () {
                         {
                             name: 'N_METHOD_DEFINITION',
                             visibility: 'public',
-                            func: 'getClass',
+                            func: {
+                                name: 'N_STRING',
+                                string: 'getClass'
+                            },
                             args: [],
                             body: {
                                 name: 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/classTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/classTest.js
@@ -73,7 +73,7 @@ describe('Transpiler __CLASS__ magic constant test', function () {
             'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function () {var scope = this;' +
+            'method: function getClass() {var scope = this;' +
             'return scope.getClassName();' +
             '}}' +
             '}, constants: {}}, namespaceScope);}());' +

--- a/test/integration/transpiler/expressions/magicConstant/dirTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/dirTest.js
@@ -62,7 +62,7 @@ describe('Transpiler __DIR__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function () {var scope = this;' +
+            'namespace.defineFunction("myFunction", function myFunction() {var scope = this;' +
             'return tools.getPathDirectory();' +
             '});' +
             'return tools.valueFactory.createNull();' +

--- a/test/integration/transpiler/expressions/magicConstant/dirTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/dirTest.js
@@ -39,7 +39,10 @@ describe('Transpiler __DIR__ magic constant test', function () {
             statements: [
                 {
                     'name': 'N_FUNCTION_STATEMENT',
-                    'func': 'myFunction',
+                    'func': {
+                        'name': 'N_STRING',
+                        'string': 'myFunction'
+                    },
                     'args': [],
                     'body': {
                         'name': 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/fileTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/fileTest.js
@@ -39,7 +39,10 @@ describe('Transpiler __FILE__ magic constant test', function () {
             statements: [
                 {
                     'name': 'N_FUNCTION_STATEMENT',
-                    'func': 'myFunction',
+                    'func': {
+                        'name': 'N_STRING',
+                        'string': 'myFunction'
+                    },
                     'args': [],
                     'body': {
                         'name': 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/fileTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/fileTest.js
@@ -62,7 +62,7 @@ describe('Transpiler __FILE__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function () {var scope = this;' +
+            'namespace.defineFunction("myFunction", function myFunction() {var scope = this;' +
             'return tools.getPath();' +
             '});' +
             'return tools.valueFactory.createNull();' +

--- a/test/integration/transpiler/expressions/magicConstant/functionTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/functionTest.js
@@ -39,7 +39,10 @@ describe('Transpiler __FUNCTION__ magic constant test', function () {
             statements: [
                 {
                     'name': 'N_FUNCTION_STATEMENT',
-                    'func': 'myFunction',
+                    'func': {
+                        'name': 'N_STRING',
+                        'string': 'myFunction'
+                    },
                     'args': [],
                     'body': {
                         'name': 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/functionTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/functionTest.js
@@ -62,7 +62,7 @@ describe('Transpiler __FUNCTION__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function () {var scope = this;' +
+            'namespace.defineFunction("myFunction", function myFunction() {var scope = this;' +
             'return scope.getFunctionName();' +
             '});' +
             'return tools.valueFactory.createNull();' +

--- a/test/integration/transpiler/expressions/magicConstant/lineTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/lineTest.js
@@ -43,7 +43,10 @@ describe('Transpiler __LINE__ magic constant test', function () {
             statements: [
                 {
                     'name': 'N_FUNCTION_STATEMENT',
-                    'func': 'myFunction',
+                    'func': {
+                        'name': 'N_STRING',
+                        'string': 'myFunction'
+                    },
                     'args': [],
                     'body': {
                         'name': 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/lineTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/lineTest.js
@@ -70,7 +70,7 @@ describe('Transpiler __LINE__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function () {var scope = this;' +
+            'namespace.defineFunction("myFunction", function myFunction() {var scope = this;' +
             'return tools.valueFactory.createInteger(3);' +
             '});' +
             'return tools.valueFactory.createNull();' +

--- a/test/integration/transpiler/expressions/magicConstant/methodTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/methodTest.js
@@ -44,7 +44,10 @@ describe('Transpiler __METHOD__ magic constant test', function () {
                         {
                             name: 'N_METHOD_DEFINITION',
                             visibility: 'public',
-                            func: 'getClass',
+                            func: {
+                                name: 'N_STRING',
+                                string: 'getClass'
+                            },
                             args: [],
                             body: {
                                 name: 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/methodTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/methodTest.js
@@ -73,7 +73,7 @@ describe('Transpiler __METHOD__ magic constant test', function () {
             'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function () {var scope = this;' +
+            'method: function getClass() {var scope = this;' +
             'return scope.getMethodName();' +
             '}}' +
             '}, constants: {}}, namespaceScope);}());' +

--- a/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
@@ -44,7 +44,10 @@ describe('Transpiler __NAMESPACE__ magic constant test', function () {
                         {
                             name: 'N_METHOD_DEFINITION',
                             visibility: 'public',
-                            func: 'getClass',
+                            func: {
+                                name: 'N_STRING',
+                                string: 'getClass'
+                            },
                             args: [],
                             body: {
                                 name: 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
@@ -73,7 +73,7 @@ describe('Transpiler __NAMESPACE__ magic constant test', function () {
             'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function () {var scope = this;' +
+            'method: function getClass() {var scope = this;' +
             'return namespaceScope.getNamespaceName();' +
             '}}' +
             '}, constants: {}}, namespaceScope);}());' +

--- a/test/integration/transpiler/operators/arrayAccessTest.js
+++ b/test/integration/transpiler/operators/arrayAccessTest.js
@@ -43,6 +43,41 @@ describe('Transpiler array access operator test', function () {
         );
     });
 
+    it('should correctly transpile a return statement with multiple array indices', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_ARRAY_INDEX',
+                    array: {
+                        name: 'N_VARIABLE',
+                        variable: 'myArray'
+                    },
+                    indices: [{
+                        index: {
+                            name: 'N_INTEGER',
+                            number: 21
+                        }
+                    }, {
+                        index: {
+                            name: 'N_INTEGER',
+                            number: 101
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return scope.getVariable("myArray").getValue().getElementByKey(tools.valueFactory.createInteger(21)).getValue().getElementByKey(tools.valueFactory.createInteger(101)).getValue();' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
     it('should correctly transpile an assignment with a single array index', function () {
         var ast = {
             name: 'N_PROGRAM',

--- a/test/integration/transpiler/sourceMapTest.js
+++ b/test/integration/transpiler/sourceMapTest.js
@@ -35,19 +35,232 @@ describe('Transpiler source map test', function () {
                     line: 4,
                     column: 6
                 }
+            },
+            options = {
+                path: 'my_module.php',
+                sourceMap: {
+                    sourceContent: '<?php $this = "is my source PHP";'
+                }
             };
 
-        expect(phpToJS.transpile(ast, {path: 'my_module.php', sourceMap: true})).to.equal(
+        expect(phpToJS.transpile(ast, options)).to.equal(
             'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
             'return tools.valueFactory.createInteger(4);' +
             'return tools.valueFactory.createNull();' +
             '})' +
-            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15X21vZHVsZS5wa' +
-            'HAiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR00ifQ==' +
+            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15X21vZHVsZS5waHAiXSwibmFtZXMiOltdLCJtY' +
+            'XBwaW5ncyI6ImdOQU9TLE9BQVUsbUNBQVYsQyIsInNvdXJjZXNDb250ZW50IjpbIjw/cGhwICR0aGlzID0gXCJpcyBteSBzb3VyY2UgUEhQXCI7Il19' +
             '\n;'
         );
     });
 
-    it('should correctly transpile functions, methods and closures with debug vars');
+    it('should correctly transpile global code, functions, methods and closures with debug vars in default (async) mode', function () {
+        var ast = {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_VARIABLE',
+                        variable: 'myGlobalCodeVar',
+                        offset: {
+                            line: 8,
+                            column: 20
+                        }
+                    },
+                    offset: {
+                        line: 8,
+                        column: 10
+                    }
+                }, {
+                    name: 'N_FUNCTION_STATEMENT',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myFunc',
+                        offset: {
+                            line: 3,
+                            column: 6
+                        }
+                    },
+                    args: [],
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [{
+                            name: 'N_RETURN_STATEMENT',
+                            expression: {
+                                name: 'N_VARIABLE',
+                                variable: 'myFunctionVar',
+                                offset: {
+                                    line: 8,
+                                    column: 20
+                                }
+                            },
+                            offset: {
+                                line: 8,
+                                column: 10
+                            }
+                        }],
+                        offset: {
+                            line: 12,
+                            column: 17
+                        }
+                    },
+                    offset: {
+                        line: 3,
+                        column: 6
+                    }
+                }, {
+                    name: 'N_CLASS_STATEMENT',
+                    className: 'MyClass',
+                    members: [{
+                        name: 'N_METHOD_DEFINITION',
+                        visibility: 'public',
+                        func: {
+                            name: 'N_STRING',
+                            string: 'myMethod',
+                            offset: {
+                                line: 6,
+                                column: 8
+                            }
+                        },
+                        args: [],
+                        body: {
+                            name: 'N_COMPOUND_STATEMENT',
+                            statements: [{
+                                name: 'N_RETURN_STATEMENT',
+                                expression: {
+                                    name: 'N_VARIABLE',
+                                    variable: 'myMethodVar',
+                                    offset: {
+                                        line: 8,
+                                        column: 20
+                                    }
+                                },
+                                offset: {
+                                    line: 8,
+                                    column: 20
+                                }
+                            }],
+                            offset: {
+                                line: 4,
+                                column: 5
+                            }
+                        },
+                        offset: {
+                            line: 11,
+                            column: 14
+                        }
+                    }],
+                    offset: {
+                        line: 2,
+                        column: 10
+                    }
+                }, {
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_CLOSURE',
+                        args: [{
+                            name: 'N_ARGUMENT',
+                            variable: {
+                                name: 'N_VARIABLE',
+                                variable: 'myArgVar',
+                                offset: {
+                                    line: 8,
+                                    column: 20
+                                }
+                            },
+                            offset: {
+                                line: 8,
+                                column: 20
+                            }
+                        }],
+                        bindings: [{
+                            name: 'N_VARIABLE',
+                            variable: 'myBoundVar',
+                            offset: {
+                                line: 8,
+                                column: 20
+                            }
+                        }],
+                        body: {
+                            name: 'N_COMPOUND_STATEMENT',
+                            statements: [{
+                                name: 'N_RETURN_STATEMENT',
+                                expression: {
+                                    name: 'N_VARIABLE',
+                                    variable: 'myClosureVar',
+                                    offset: {
+                                        line: 8,
+                                        column: 20
+                                    }
+                                },
+                                offset: {
+                                    line: 8,
+                                    column: 20
+                                }
+                            }],
+                            offset: {
+                                line: 8,
+                                column: 20
+                            }
+                        },
+                        offset: {
+                            line: 8,
+                            column: 20
+                        }
+                    },
+                    offset: {
+                        line: 8,
+                        column: 20
+                    }
+                }],
+                offset: {
+                    line: 4,
+                    column: 6
+                }
+            },
+            options = {
+                path: 'my_module.php',
+                sourceMap: {
+                    sourceContent: '<?php $this = "is my source PHP";'
+                }
+            };
+
+        expect(phpToJS.transpile(ast, options)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            // Debug variable will be inserted for better debugging in Chrome dev tools
+            'var $myGlobalCodeVar = tools.createDebugVar(scope, "myGlobalCodeVar");' +
+            'namespace.defineFunction("myFunc", function myFunc() {' +
+            'var scope = this;' +
+            'var $this = tools.createDebugVar(scope, "this");' +
+            'var $myFunctionVar = tools.createDebugVar(scope, "myFunctionVar");' +
+            'return scope.getVariable("myFunctionVar").getValue();' +
+            '});' +
+            '(function () {var currentClass = namespace.defineClass("MyClass", {' +
+            'superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            '"myMethod": {' +
+            'isStatic: false, method: function myMethod() {' +
+            'var scope = this;var $this = tools.createDebugVar(scope, "this");' +
+            'var $myMethodVar = tools.createDebugVar(scope, "myMethodVar");' +
+            'return scope.getVariable("myMethodVar").getValue();' +
+            '}' +
+            '}}, constants: {}}, namespaceScope);}());' +
+            'return scope.getVariable("myGlobalCodeVar").getValue();' +
+            'return tools.createClosure((function (parentScope) { return function ($myArgVar) {' +
+            'var scope = this;scope.getVariable("myArgVar").setValue($myArgVar.getValue());' +
+            'var $myArgVar = tools.createDebugVar(scope, "myArgVar");' +
+            'var $this = tools.createDebugVar(scope, "this");' +
+            'var $myClosureVar = tools.createDebugVar(scope, "myClosureVar");' +
+            'scope.getVariable("myBoundVar").setValue(parentScope.getVariable("myBoundVar").getValue());' +
+            'var $myBoundVar = tools.createDebugVar(scope, "myBoundVar");' +
+            'return scope.getVariable("myClosureVar").getValue();' +
+            '}; }(scope)), scope);' +
+            'return tools.valueFactory.createNull();' +
+            '})' +
+            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15X21vZHVsZS5waH' +
+            'AiXSwibmFtZXMiOlsiTl9TVFJJTkciLCIkbXlGdW5jdGlvblZhciIsIiRteU1ldGhvZFZhciIsIiRteUdsb2JhbENvZGVWYXIiLCIkbXlCb3VuZFZhciIsIiRteUNsb3N1cmVWYXIiXSwibWFwcGluZ3MiOiJzUkFFSyw0Q0FBQUEsTUFBQSx1SUFLSSxPQUFVQyw2Q0FBVixDQUxKLEdBREksaUtBU0ksbUNBTE5ELFFBS00sbUlBSE0sT0FBQUUsMkNBQUEsQ0FHTixFQVRKLHdDQU1BLE9BQVVDLCtDQUFWLENBQVUsdWFBQUFDLFdBQUEsb0RBQUFDLDRDQUFBLHNCIiwic291cmNlc0NvbnRlbnQiOlsiPD9waHAgJHRoaXMgPSBcImlzIG15IHNvdXJjZSBQSFBcIjsiXX0=' +
+            '\n;'
+        );
+    });
 });

--- a/test/integration/transpiler/sourceMapTest.js
+++ b/test/integration/transpiler/sourceMapTest.js
@@ -1,0 +1,53 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../..');
+
+describe('Transpiler source map test', function () {
+    it('should correctly transpile a simple return statement in default (async) mode', function () {
+        var ast = {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: '4',
+                        offset: {
+                            line: 8,
+                            column: 20
+                        }
+                    },
+                    offset: {
+                        line: 8,
+                        column: 10
+                    }
+                }],
+                offset: {
+                    line: 4,
+                    column: 6
+                }
+            };
+
+        expect(phpToJS.transpile(ast, {path: 'my_module.php', sourceMap: true})).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createInteger(4);' +
+            'return tools.valueFactory.createNull();' +
+            '})' +
+            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15X21vZHVsZS5wa' +
+            'HAiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR00ifQ==' +
+            '\n;'
+        );
+    });
+
+    it('should correctly transpile functions, methods and closures with debug vars');
+});

--- a/test/integration/transpiler/statements/class/abstractTest.js
+++ b/test/integration/transpiler/statements/class/abstractTest.js
@@ -22,7 +22,10 @@ describe('Transpiler class statement with abstract methods test', function () {
                 className: 'AbstractMyClass',
                 members: [{
                     name: 'N_ABSTRACT_METHOD_DEFINITION',
-                    func: 'myMethod',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myMethod'
+                    },
                     visibility: 'protected',
                     args: [{
                         name: 'N_ARGUMENT',
@@ -41,7 +44,10 @@ describe('Transpiler class statement with abstract methods test', function () {
                     }]
                 }, {
                     name: 'N_ABSTRACT_STATIC_METHOD_DEFINITION',
-                    method: 'myMethod',
+                    method: {
+                        name: 'N_STRING',
+                        string: 'myMethod'
+                    },
                     visibility: 'protected',
                     args: [{
                         name: 'N_ARGUMENT',

--- a/test/integration/transpiler/statements/forTest.js
+++ b/test/integration/transpiler/statements/forTest.js
@@ -91,4 +91,45 @@ describe('Transpiler "for" statement test', function () {
             '});'
         );
     });
+
+    it('should correctly transpile an infinite for loop', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_FOR_STATEMENT',
+                initializer: {
+                    name: 'N_COMMA_EXPRESSION',
+                    expressions: []
+                },
+                condition: {
+                    name: 'N_COMMA_EXPRESSION',
+                    expressions: []
+                },
+                update: {
+                    name: 'N_COMMA_EXPRESSION',
+                    expressions: []
+                },
+                body: {
+                    name: 'N_COMPOUND_STATEMENT',
+                    statements: [{
+                        name: 'N_ECHO_STATEMENT',
+                        expression: {
+                            name: 'N_VARIABLE',
+                            variable: 'i'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'block_1: for (;;) {' +
+            'stdout.write(scope.getVariable("i").getValue().coerceToString().getNative());' +
+            '}' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
 });

--- a/test/integration/transpiler/statements/functionTest.js
+++ b/test/integration/transpiler/statements/functionTest.js
@@ -33,7 +33,7 @@ describe('Transpiler function statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("gogo", function () {var scope = this;});' +
+            'namespace.defineFunction("gogo", function gogo() {var scope = this;});' +
             'return tools.valueFactory.createNull();' +
             '});'
         );

--- a/test/integration/transpiler/statements/functionTest.js
+++ b/test/integration/transpiler/statements/functionTest.js
@@ -18,7 +18,10 @@ describe('Transpiler function statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_FUNCTION_STATEMENT',
-                func: 'gogo',
+                func: {
+                    name: 'N_STRING',
+                    string: 'gogo'
+                },
                 args: [],
                 body: {
                     name: 'N_COMPOUND_STATEMENT',

--- a/test/integration/transpiler/statements/interfaceTest.js
+++ b/test/integration/transpiler/statements/interfaceTest.js
@@ -28,7 +28,10 @@ describe('Transpiler interface statement test', function () {
                     }
                 }, {
                     name: 'N_STATIC_INTERFACE_METHOD_DEFINITION',
-                    method: 'doSomething',
+                    method: {
+                        name: 'N_STRING',
+                        string: 'doSomething'
+                    },
                     visibility: 'public',
                     args: [{
                         name: 'N_ARGUMENT',
@@ -40,7 +43,10 @@ describe('Transpiler interface statement test', function () {
                     }]
                 }, {
                     name: 'N_INTERFACE_METHOD_DEFINITION',
-                    func: 'doSomethingElse',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'doSomethingElse'
+                    },
                     visibility: 'public',
                     args: [{
                         name: 'N_ARGUMENT',

--- a/test/integration/transpiler/statements/namespaceTest.js
+++ b/test/integration/transpiler/statements/namespaceTest.js
@@ -61,7 +61,7 @@ describe('Transpiler namespace statement test', function () {
             'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function () {var scope = this;' +
+            'method: function getClass() {var scope = this;' +
             'return namespaceScope.getNamespaceName();' +
             '}}' +
             '}, constants: {}}, namespaceScope);}());' +

--- a/test/integration/transpiler/statements/namespaceTest.js
+++ b/test/integration/transpiler/statements/namespaceTest.js
@@ -1,0 +1,72 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler namespace statement test', function () {
+    it('should correctly transpile a return statement inside class method inside namespace', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [
+                {
+                    name: 'N_NAMESPACE_STATEMENT',
+                    namespace: 'This\\Is\\My\\Space',
+                    statements: [
+                        {
+                            name: 'N_CLASS_STATEMENT',
+                            className: 'MyClass',
+                            members: [
+                                {
+                                    name: 'N_METHOD_DEFINITION',
+                                    visibility: 'public',
+                                    func: {
+                                        name: 'N_STRING',
+                                        string: 'getClass'
+                                    },
+                                    args: [],
+                                    body: {
+                                        name: 'N_COMPOUND_STATEMENT',
+                                        statements: [
+                                            {
+                                                name: 'N_RETURN_STATEMENT',
+                                                expression: {
+                                                    name: 'N_MAGIC_NAMESPACE_CONSTANT'
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.createNamespaceScope(namespace), namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'if (namespaceResult = (function (globalNamespace) {' +
+            'var namespace = globalNamespace.getDescendant("This\\\\Is\\\\My\\\\Space"), namespaceScope = tools.createNamespaceScope(namespace);' +
+            '(function () {' +
+            'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            '"getClass": {' +
+            'isStatic: false, ' +
+            'method: function () {var scope = this;' +
+            'return namespaceScope.getNamespaceName();' +
+            '}}' +
+            '}, constants: {}}, namespaceScope);}());' +
+            '}(namespace))) { return namespaceResult; }' +
+            'return tools.valueFactory.createNull();}'
+        );
+    });
+});


### PR DESCRIPTION
Adds support for generating source maps, if the `sourceMap` option is set. Example:

``` javascript
var js = phpToJS.transpile(phpAST, {
    'path': '/path/to/my_module.php',
    'sourceMap': {
        'sourceContent': '<?php $this = "is my PHP source";'
    }
});
```
