### PR TITLE
Add Promise-sync mode

### DIFF
--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -11,6 +11,7 @@
 
 var _ = require('microdash'),
     BARE = 'bare',
+    MODE = 'mode',
     PATH = 'path',
     PREFIX = 'prefix',
     RUNTIME_PATH = 'runtimePath',
@@ -1577,9 +1578,18 @@ module.exports = {
                 context.createStatementSourceNode = createSpecificSourceNode;
             }
 
-            // Optional synchronous mode
-            if (options[SYNC]) {
+            if (options[MODE] && options[SYNC]) {
+                throw new Error('Only one of "mode" and "sync" options should be specified');
+            }
+
+            if (options[MODE] === 'sync' || options[SYNC]) {
+                // Synchronous mode
                 name += '/sync';
+            } else if (options[MODE] === 'psync') {
+                // Promise-synchronous mode
+                name += '/psync';
+            } else if (options[MODE] && options[MODE] !== 'async') {
+                throw new Error('Invalid mode "' + options[MODE] + '" given');
             }
 
             body.push(processBlock(hoistDeclarations(node.statements), interpret, context));

--- a/test/integration/transpiler/modeOptionTest.js
+++ b/test/integration/transpiler/modeOptionTest.js
@@ -1,0 +1,133 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../..');
+
+describe('Transpiler "mode" option test', function () {
+    it('should correctly transpile a return statement in explicit sync mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {mode: 'sync'})).to.equal(
+            'require(\'phpruntime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createString("my result");' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a return statement in explicit async mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {mode: 'async'})).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createString("my result");' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a return statement in implicit async mode (neither "mode" nor "sync" options specified)', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createString("my result");' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a return statement in explicit promise-sync mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {mode: 'psync'})).to.equal(
+            'require(\'phpruntime/psync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createString("my result");' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should throw when both "sync" and "mode" options are given, even when not conflicting', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {mode: 'sync', sync: true});
+        }).to.throw('Only one of "mode" and "sync" options should be specified');
+    });
+
+    it('should throw when an invalid "mode" option is given', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {mode: 'invalid-mode'});
+        }).to.throw('Invalid mode "invalid-mode" given');
+    });
+});

--- a/test/integration/transpiler/returnTest.js
+++ b/test/integration/transpiler/returnTest.js
@@ -34,27 +34,6 @@ describe('Transpiler "return" statement test', function () {
         );
     });
 
-    it('should correctly transpile a return statement with an operand of 6 in synchronous mode', function () {
-        var ast = {
-            name: 'N_PROGRAM',
-            statements: [{
-                name: 'N_RETURN_STATEMENT',
-                expression: {
-                    name: 'N_INTEGER',
-                    number: '6'
-                }
-            }]
-        };
-
-        expect(phpToJS.transpile(ast, {sync: true})).to.equal(
-            'require(\'phpruntime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(6);' +
-            'return tools.valueFactory.createNull();' +
-            '});'
-        );
-    });
-
     it('should correctly transpile a return statement with an operand of 6 in bare mode', function () {
         var ast = {
             name: 'N_PROGRAM',

--- a/test/integration/transpiler/runtimePathOptionTest.js
+++ b/test/integration/transpiler/runtimePathOptionTest.js
@@ -34,7 +34,7 @@ describe('Transpiler "return" statement test', function () {
         );
     });
 
-    it('should correctly transpile a return statement with an operand of 6 in synchronous mode', function () {
+    it('should correctly transpile a return statement with an operand of 6 in synchronous mode using "sync" option', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -47,6 +47,27 @@ describe('Transpiler "return" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {sync: true, runtimePath: '/path/to/runtime'})).to.equal(
+            'require(\'/path/to/runtime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createInteger(6);' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a return statement with an operand of 6 in synchronous mode using "mode" option', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_INTEGER',
+                    number: '6'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {mode: 'sync', runtimePath: '/path/to/runtime'})).to.equal(
             'require(\'/path/to/runtime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
             'return tools.valueFactory.createInteger(6);' +

--- a/test/integration/transpiler/syncOptionTest.js
+++ b/test/integration/transpiler/syncOptionTest.js
@@ -1,0 +1,57 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../..');
+
+describe('Transpiler "sync" option test', function () {
+    it('should correctly transpile a return statement in explicit sync mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {sync: true})).to.equal(
+            'require(\'phpruntime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createString("my result");' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a return statement in explicit async mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_LITERAL',
+                    string: 'my result'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {sync: false})).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createString("my result");' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+});


### PR DESCRIPTION
This change allows a consistent public API across async mode and (p)sync modes. Previously, the consuming application needed to deal with either a Promise (as returned in async mode) or the resulting Value object. This additional effort made it more likely that only one of the options would be supported, meaning that switching between modes (eg. to enable the experimental debugger) would involve code changes.

Also see:

PHPCore PR: uniter/phpcore#3
PHPRuntime PR: uniter/phpruntime#8
PHPify PR: uniter/phpify#2