### PR TITLE
Error handling improvements for PHP 7 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@sinonjs/commons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
-      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -23,14 +23,14 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
-      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.3.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
       }
     },
     "@sinonjs/text-encoding": {
@@ -170,19 +170,25 @@
       "dev": true
     },
     "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
         "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
           "dev": true
         }
       }
@@ -219,13 +225,24 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.51",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "^1.0.0"
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+          "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+          "requires": {
+            "d": "^1.0.1",
+            "ext": "^1.1.2"
+          }
+        }
       }
     },
     "es6-iterator": {
@@ -280,6 +297,21 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -293,9 +325,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -348,9 +380,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "isarray": {
@@ -360,9 +392,9 @@
       "dev": true
     },
     "jshint": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz",
-      "integrity": "sha512-e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
+      "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
@@ -445,6 +477,22 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -459,22 +507,22 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nise": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
-      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^4.1.0",
+        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       },
       "dependencies": {
         "@sinonjs/formatio": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
-          "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+          "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
           "dev": true,
           "requires": {
             "@sinonjs/commons": "^1",
@@ -482,10 +530,13 @@
           }
         },
         "lolex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
-          "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
-          "dev": true
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
         }
       }
     },
@@ -515,9 +566,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
@@ -530,9 +581,9 @@
       "dev": true
     },
     "phpcommon": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-1.13.0.tgz",
-      "integrity": "sha512-gPBLulAOD0seWGPnqrLgZsNv4u5TosPtdTPQu6oquHLR4VelV2ydV1W6sX76VEkARvs3aOm0ohcLGegQ8Pi1bg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-2.0.0.tgz",
+      "integrity": "sha512-ZyJ6d9x5qh8RQRB0WTOhgtDBzCvLTtJNFNoM43HHZW9nTSqV3sUZZTwbua0ktvh5fne15huCNT9NJp2bl/0aTA==",
       "requires": {
         "microdash": "~1",
         "template-string": "~1"
@@ -578,9 +629,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
-      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
+      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "es6-set": "^0.1.5",
     "microdash": "~1",
-    "phpcommon": "^1.13.0",
+    "phpcommon": "^2.0.0",
     "source-map": "^0.5.6",
     "source-map-to-comment": "^1.1.0",
     "transpiler": "~1.2"

--- a/src/builtin/messages/transpiler.js
+++ b/src/builtin/messages/transpiler.js
@@ -1,0 +1,26 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+/*
+ * Translations for transpilation-related errors
+ */
+module.exports = {
+    'en_GB': {
+        'core': {
+            'goto_disallowed': '\'goto\' into loop or switch statement is disallowed',
+            'goto_to_undefined_label': '\'goto\' to undefined label \'${label}\'',
+            'interface_method_body_not_allowed': 'Interface function ${className}::${methodName}() cannot contain body',
+            'interface_property_not_allowed': 'Interfaces may not include member variables',
+            'label_already_defined': 'Label \'${label}\' already defined',
+            'operator_requires_positive_number': '\'${operator}\' operator accepts only positive numbers'
+        }
+    }
+};

--- a/src/builtin/messages/transpiler.js
+++ b/src/builtin/messages/transpiler.js
@@ -15,12 +15,16 @@
 module.exports = {
     'en_GB': {
         'core': {
+            'break_or_continue_in_wrong_context': '\'${operator}\' not in the \'loop\' or \'switch\' context',
+            'break_or_continue_non_integer_operand': '\'${operator}\' operator with non-integer operand is no longer supported',
+            'cannot_break_or_continue': 'Cannot \'${operator}\' ${levels} levels',
+            'expect_exactly_one_arg': '${name}() must take exactly 1 argument',
             'goto_disallowed': '\'goto\' into loop or switch statement is disallowed',
             'goto_to_undefined_label': '\'goto\' to undefined label \'${label}\'',
             'interface_method_body_not_allowed': 'Interface function ${className}::${methodName}() cannot contain body',
             'interface_property_not_allowed': 'Interfaces may not include member variables',
             'label_already_defined': 'Label \'${label}\' already defined',
-            'operator_requires_positive_number': '\'${operator}\' operator accepts only positive numbers'
+            'operator_requires_positive_integer': '\'${operator}\' operator accepts only positive integers'
         }
     }
 };

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -738,6 +738,19 @@ module.exports = {
                 )
             };
         },
+        'N_CONSTANT_STATEMENT': function (node, interpret, context) {
+            var codeChunks = [];
+
+            _.each(node.constants, function (constant) {
+                codeChunks.push(
+                    'namespace.defineConstant(' + JSON.stringify(constant.constant) + ', ',
+                    interpret(constant.value),
+                    ');'
+                );
+            });
+
+            return context.createStatementSourceNode(codeChunks, node);
+        },
         'N_CONTINUE_STATEMENT': function (node, interpret, context) {
             var levels = node.levels.number,
                 statement,

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -119,7 +119,7 @@ function buildExtraFunctionDefinitionArgChunks(argSpecs) {
 
     // NB: If there are some optional args left at the end, omit them
 
-    return argChunks.map(function (argChunk, index) {
+    return argChunks.map(function (argChunk) {
         return [', '].concat(argChunk);
     });
 }
@@ -269,10 +269,9 @@ function interpretFunction(nameNode, argNodes, bindingNodes, statementNode, inte
  *
  * @param {Object[]} argNodes
  * @param {Function} interpret
- * @param {Object} context
  * @return {Array}
  */
-function interpretFunctionArgs(argNodes, interpret, context) {
+function interpretFunctionArgs(argNodes, interpret) {
     var allArgCodeChunks = [];
 
     _.each(argNodes, function (argNode, argIndex) {
@@ -693,7 +692,7 @@ module.exports = {
             var func = interpretFunction(null, node.args, node.bindings, node.body, interpret, context),
                 extraArgChunks = buildExtraFunctionDefinitionArgChunks([
                     {
-                        value: interpretFunctionArgs(node.args, interpret, context),
+                        value: interpretFunctionArgs(node.args, interpret),
                         emptyValue: '[]'
                     },
                     {
@@ -1151,7 +1150,7 @@ module.exports = {
             func = interpretFunction(node.func, node.args, null, node.body, interpret, context);
             extraArgChunks = buildExtraFunctionDefinitionArgChunks([
                 {
-                    value: interpretFunctionArgs(node.args, interpret, context),
+                    value: interpretFunctionArgs(node.args, interpret),
                     emptyValue: '[]'
                 },
                 {
@@ -1503,7 +1502,7 @@ module.exports = {
             var extraArgChunks = buildExtraFunctionDefinitionArgChunks([
                 {
                     name: 'args',
-                    value: interpretFunctionArgs(node.args, interpret, context),
+                    value: interpretFunctionArgs(node.args, interpret),
                     emptyValue: '[]'
                 },
                 {
@@ -1983,7 +1982,7 @@ module.exports = {
             var extraArgChunks = buildExtraFunctionDefinitionArgChunks([
                 {
                     name: 'args',
-                    value: interpretFunctionArgs(node.args, interpret, context),
+                    value: interpretFunctionArgs(node.args, interpret),
                     emptyValue: '[]'
                 },
                 {

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -1737,7 +1737,7 @@ module.exports = {
             );
         },
         'N_RETURN_STATEMENT': function (node, interpret, context) {
-            var expression = interpret(node.expression);
+            var expression = node.expression ? interpret(node.expression) : null;
 
             return context.createStatementSourceNode(
                 ['return '].concat(expression ? expression : 'tools.valueFactory.createNull()', ';'),

--- a/test/integration/transpiler/extensions/customStatementTest.js
+++ b/test/integration/transpiler/extensions/customStatementTest.js
@@ -1,0 +1,69 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler custom statement test', function () {
+    it('should correctly transpile a custom trap statement between function calls', function () {
+        // Source code: 'firstFunc(); trap_it @ 21; secondFunc();',
+        var ast = {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_FUNCTION_CALL',
+                        func: {
+                            name: 'N_STRING',
+                            string: 'firstFunc'
+                        },
+                        args: []
+                    }
+                }, {
+                    name: 'N_CUSTOM_TRAP_IT',
+                    arg: {
+                        name: 'N_INTEGER',
+                        number: '21'
+                    }
+                }, {
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_FUNCTION_CALL',
+                        func: {
+                            name: 'N_STRING',
+                            string: 'secondFunc'
+                        },
+                        args: []
+                    }
+                }]
+            },
+            options = {
+                nodes: {
+                    'N_CUSTOM_TRAP_IT': function (node, interpret, context) {
+                        return context.createStatementSourceNode(
+                            ['stdout.write("Trapped: " + ', interpret(node.arg, {getValue: true}), '.getNative());'],
+                            node
+                        );
+                    }
+                }
+            };
+
+        expect(phpToJS.transpile(ast, {}, options)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            '(tools.valueFactory.createBarewordString("firstFunc").call([], namespaceScope) || tools.valueFactory.createNull());' +
+            'stdout.write("Trapped: " + tools.valueFactory.createInteger(21).getNative());' +
+            '(tools.valueFactory.createBarewordString("secondFunc").call([], namespaceScope) || tools.valueFactory.createNull());' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/lineNumberTest.js
+++ b/test/integration/transpiler/lineNumberTest.js
@@ -333,7 +333,9 @@ describe('Transpiler line numbers test', function () {
                         visibility: 'public',
                         args: [{
                             name: 'N_ARGUMENT',
-                            type: 'array',
+                            type: {
+                                name: 'N_ARRAY_TYPE'
+                            },
                             variable: {
                                 name: 'N_VARIABLE',
                                 variable: 'myBodyArgs',
@@ -459,7 +461,7 @@ describe('Transpiler line numbers test', function () {
             'var scope = this;' +
             'var line;tools.instrument(function () {return line;});' +
             'line = 8;return (line = 8, scope.getVariable("myFunctionVar").getValue());' +
-            '}, namespaceScope);' +
+            '}, namespaceScope, [], 3);' +
             'line = 2;(function () {var currentClass = namespace.defineClass("MyClass", {' +
             'superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"myMethod": {' +
@@ -467,7 +469,7 @@ describe('Transpiler line numbers test', function () {
             'var scope = this;' +
             'var line;tools.instrument(function () {return line;});' +
             'line = 8;return (line = 10, scope.getVariable("myMethodVar").getValue());' +
-            '}' +
+            '}, args: [], line: 11' +
             '}}, constants: {}}, namespaceScope);}());' +
             'line = 8;return (line = 1, scope.getVariable("myGlobalCodeVar").getValue());' +
             'line = 3;(function () {var currentClass = namespace.defineClass("MyThingInterface", {' +
@@ -487,7 +489,9 @@ describe('Transpiler line numbers test', function () {
             'scope.getVariable("myArgVar").setValue($myArgVar.getValue());' +
             'scope.getVariable("myBoundVar").setValue(parentScope.getVariable("myBoundVar").getValue());' +
             'line = 8;return (line = 11, scope.getVariable("myClosureVar").getValue());' +
-            '}; }(scope)), scope));' +
+            '}; }(scope)), scope, namespaceScope, [' +
+            '{"name":"myArgVar"}' +
+            '], false, 12));' +
             'return tools.valueFactory.createNull();' +
             '});'
         );

--- a/test/integration/transpiler/newTest.js
+++ b/test/integration/transpiler/newTest.js
@@ -46,4 +46,37 @@ describe('Transpiler new expression test', function () {
             '});'
         );
     });
+
+    it('should correctly transpile a new expression in function call argument in default (async) mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_FUNCTION_CALL',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myFunc'
+                    },
+                    args: [{
+                        name: 'N_NEW_EXPRESSION',
+                        className: {
+                            name: 'N_VARIABLE',
+                            variable: 'myClassName'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            '(tools.valueFactory.createBarewordString("myFunc").call([' +
+            'tools.createInstance(namespaceScope, scope.getVariable("myClassName").getValue(), [])' +
+            '], namespaceScope) || tools.valueFactory.createNull());' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
 });

--- a/test/integration/transpiler/returnTest.js
+++ b/test/integration/transpiler/returnTest.js
@@ -13,6 +13,23 @@ var expect = require('chai').expect,
     phpToJS = require('../../..');
 
 describe('Transpiler "return" statement test', function () {
+    it('should correctly transpile a return statement with no operand in default (async) mode', function () {
+        var ast = {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT'
+                }]
+            };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createNull();' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
     it('should correctly transpile a return statement with an operand of 4 in default (async) mode', function () {
         var ast = {
                 name: 'N_PROGRAM',

--- a/test/integration/transpiler/sourceMapTest.js
+++ b/test/integration/transpiler/sourceMapTest.js
@@ -306,14 +306,16 @@ describe('Transpiler source map test', function () {
             'scope.getVariable("myBoundVar").setValue(parentScope.getVariable("myBoundVar").getValue());' +
             'var $myBoundVar = tools.createDebugVar(scope, "myBoundVar");' +
             'return scope.getVariable("myClosureVar").getValue();' +
-            '}; }(scope)), scope);' +
+            '}; }(scope)), scope, namespaceScope, [' +
+            '{"name":"myArgVar"}' +
+            ']);' +
             'return tools.valueFactory.createNull();' +
             '});' +
             '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15X21' +
             'vZHVsZS5waHAiXSwibmFtZXMiOlsiTl9TVFJJTkciLCIkbXlGdW5jdGlvblZhciIsIiRteU1ldGhvZFZhciIsIiRteUds' +
             'b2JhbENvZGVWYXIiLCIkbXlCb3VuZFZhciIsIiRteUNsb3N1cmVWYXIiXSwibWFwcGluZ3MiOiI2UUFFSyw0Q0FBQUEsT' +
             '0FBQSx1SUFLSSxPQUFVQyw2Q0FBVixDQUxKLG1CQURJLGlLQVNJLG1DQUxORCxTQUtNLG1JQUhNLE9BQUFFLDJDQUFBLE' +
-            'NBR04sRUFUSix3Q0FNQSxPQUFVQywrQ0FBVixDQUFVLHVhQUFBQyxXQUFBLG9EQUFBQyw0Q0FBQSxzQiIsInNvdXJjZXN' +
+            'NBR04sRUFUSix3Q0FNQSxPQUFVQywrQ0FBVixDQUFVLHVhQUFBQyxXQUFBLG9EQUFBQyw0Q0FBQSw2RCIsInNvdXJjZXN' +
             'Db250ZW50IjpbIjw/cGhwICR0aGlzID0gXCJpcyBteSBzb3VyY2UgUEhQXCI7Il19' +
             '\n'
         );

--- a/test/integration/transpiler/statements/breakTest.js
+++ b/test/integration/transpiler/statements/breakTest.js
@@ -255,8 +255,11 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(function () {
-            phpToJS.transpile(ast, {path: '/path/to/module.php', lineNumbers: true});
-        }).to.throw(PHPFatalError, '\'break\' operator accepts only positive numbers in /path/to/module.php on line 4');
+            phpToJS.transpile(ast, {path: '/path/to/module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: \'break\' operator accepts only positive integers in /path/to/module.php on line 4'
+        );
     });
 
     it('should throw a compile time fatal error when negative one is given as the break level', function () {
@@ -275,39 +278,45 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(function () {
-            phpToJS.transpile(ast, {path: '/path/to/another.php', lineNumbers: true});
-        }).to.throw(PHPFatalError, '\'break\' operator accepts only positive numbers in /path/to/another.php on line 5');
+            phpToJS.transpile(ast, {path: '/path/to/another.php'});
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: \'break\' operator with non-integer operand is no longer supported'
+        );
     });
 
-    it('should throw a runtime fatal error when not inside a looping structure for 1 level', function () {
+    it('should throw a compile time fatal error when not inside a looping structure for 1 level', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_BREAK_STATEMENT',
                 levels: {
                     name: 'N_INTEGER',
-                    number: 1
-                }
-            }]
+                    number: 1,
+                    bounds: {start: {line: 9, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
-        expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'tools.throwCannotBreakOrContinue(1);' +
-            'return tools.valueFactory.createNull();' +
-            '});'
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/my/my_module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: \'break\' not in the \'loop\' or \'switch\' context in /my/my_module.php on line 9'
         );
     });
 
-    it('should throw a runtime fatal error when code is not enough levels deep', function () {
+    it('should throw a compile time fatal error when code is not enough levels deep', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_WHILE_STATEMENT',
                 condition: {
                     name: 'N_INTEGER',
-                    number: 21
+                    number: 21,
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
@@ -315,21 +324,23 @@ describe('Transpiler "break" statement test', function () {
                         name: 'N_BREAK_STATEMENT',
                         levels: {
                             name: 'N_INTEGER',
-                            number: 2
-                        }
-                    }]
-                }
-            }]
+                            number: 2,
+                            bounds: {start: {line: 6, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
-        expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: while (tools.valueFactory.createInteger(21).coerceToBoolean().getNative()) {' +
-            'tools.throwCannotBreakOrContinue(2);' +
-            '}' +
-            'return tools.valueFactory.createNull();' +
-            '});'
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/your/your_module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: Cannot \'break\' 2 levels in /your/your_module.php on line 6'
         );
     });
 });

--- a/test/integration/transpiler/statements/breakTest.js
+++ b/test/integration/transpiler/statements/breakTest.js
@@ -239,38 +239,44 @@ describe('Transpiler "break" statement test', function () {
         );
     });
 
-    it('should throw a fatal error when zero is given as the break level', function () {
+    it('should throw a compile time fatal error when zero is given as the break level', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_BREAK_STATEMENT',
                 levels: {
                     name: 'N_INTEGER',
-                    number: 0
-                }
-            }]
+                    number: 0,
+                    bounds: {start: {line: 4, column: 10}}
+                },
+                bounds: {start: {line: 2, column: 4}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'break\' operator accepts only positive numbers');
+            phpToJS.transpile(ast, {path: '/path/to/module.php', lineNumbers: true});
+        }).to.throw(PHPFatalError, '\'break\' operator accepts only positive numbers in /path/to/module.php on line 4');
     });
 
-    it('should throw a fatal error when negative one is given as the break level', function () {
+    it('should throw a compile time fatal error when negative one is given as the break level', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_BREAK_STATEMENT',
                 levels: {
                     name: 'N_INTEGER',
-                    number: -1
-                }
-            }]
+                    number: -1,
+                    bounds: {start: {line: 5, column: 10}}
+                },
+                bounds: {start: {line: 2, column: 4}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'break\' operator accepts only positive numbers');
+            phpToJS.transpile(ast, {path: '/path/to/another.php', lineNumbers: true});
+        }).to.throw(PHPFatalError, '\'break\' operator accepts only positive numbers in /path/to/another.php on line 5');
     });
 
     it('should throw a runtime fatal error when not inside a looping structure for 1 level', function () {

--- a/test/integration/transpiler/statements/class/abstractTest.js
+++ b/test/integration/transpiler/statements/class/abstractTest.js
@@ -29,14 +29,20 @@ describe('Transpiler class statement with abstract methods test', function () {
                     visibility: 'protected',
                     args: [{
                         name: 'N_ARGUMENT',
-                        type: 'MyArg',
+                        type: {
+                            name: 'N_CLASS_TYPE',
+                            className: 'MyArg'
+                        },
                         variable: {
                             name: 'N_VARIABLE',
                             variable: 'arg1'
                         }
                     }, {
                         name: 'N_ARGUMENT',
-                        type: 'YourArg',
+                        type: {
+                            name: 'N_CLASS_TYPE',
+                            className: 'YourArg'
+                        },
                         variable: {
                             name: 'N_VARIABLE',
                             variable: 'arg2'
@@ -51,14 +57,20 @@ describe('Transpiler class statement with abstract methods test', function () {
                     visibility: 'protected',
                     args: [{
                         name: 'N_ARGUMENT',
-                        type: 'MyArg',
+                        type: {
+                            name: 'N_CLASS_TYPE',
+                            className: 'MyArg'
+                        },
                         variable: {
                             name: 'N_VARIABLE',
                             variable: 'arg1'
                         }
                     }, {
                         name: 'N_ARGUMENT',
-                        type: 'YourArg',
+                        type: {
+                            name: 'N_CLASS_TYPE',
+                            className: 'YourArg'
+                        },
                         variable: {
                             name: 'N_VARIABLE',
                             variable: 'arg2'

--- a/test/integration/transpiler/statements/class/methodDefinitionTest.js
+++ b/test/integration/transpiler/statements/class/methodDefinitionTest.js
@@ -26,7 +26,19 @@ describe('Transpiler class statement with method definitions test', function () 
                         name: 'N_STRING',
                         string: 'myInstanceMethod'
                     },
-                    args: [],
+                    args: [{
+                        name: 'N_ARGUMENT',
+                        type: {
+                            name: 'N_ARRAY_TYPE'
+                        },
+                        variable: {
+                            name: 'N_REFERENCE',
+                            operand: {
+                                name: 'N_VARIABLE',
+                                variable: 'myByRefArrayArg'
+                            }
+                        }
+                    }],
                     body: {
                         name: 'N_COMPOUND_STATEMENT',
                         statements: [{
@@ -45,7 +57,16 @@ describe('Transpiler class statement with method definitions test', function () 
                         name: 'N_STRING',
                         string: 'myStaticMethod'
                     },
-                    args: [],
+                    args: [{
+                        name: 'N_ARGUMENT',
+                        type: {
+                            name: 'N_ARRAY_TYPE'
+                        },
+                        variable: {
+                            name: 'N_VARIABLE',
+                            variable: 'myCallableArg'
+                        }
+                    }],
                     body: {
                         name: 'N_COMPOUND_STATEMENT',
                         statements: [{
@@ -71,15 +92,21 @@ describe('Transpiler class statement with method definitions test', function () 
             'properties: {}, ' +
             'methods: {' +
             '"myInstanceMethod": {' +
-            'isStatic: false, method: function _myInstanceMethod() {' +
+            'isStatic: false, method: function _myInstanceMethod($myByRefArrayArg) {' +
             'var scope = this;' +
+            'scope.getVariable("myByRefArrayArg").setReference($myByRefArrayArg.getReference());' +
             'return tools.valueFactory.createInteger(21);' +
-            '}}, ' +
+            '}, args: [' +
+            '{"type":"array","name":"myByRefArrayArg","ref":true}' +
+            ']}, ' +
             '"myStaticMethod": {' +
-            'isStatic: true, method: function _myStaticMethod() {' +
+            'isStatic: true, method: function _myStaticMethod($myCallableArg) {' +
             'var scope = this;' +
+            'scope.getVariable("myCallableArg").setValue($myCallableArg.getValue());' +
             'return tools.valueFactory.createInteger(101);' +
-            '}}' +
+            '}, args: [' +
+            '{"type":"array","name":"myCallableArg"}' +
+            ']}' +
             '}, ' +
             'constants: {}' +
             '}, namespaceScope);' +

--- a/test/integration/transpiler/statements/class/methodDefinitionTest.js
+++ b/test/integration/transpiler/statements/class/methodDefinitionTest.js
@@ -1,0 +1,91 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler class statement with method definitions test', function () {
+    it('should correctly transpile a class with instance and static method definitions', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CLASS_STATEMENT',
+                className: 'MyClass',
+                members: [{
+                    name: 'N_METHOD_DEFINITION',
+                    visibility: 'public',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myInstanceMethod'
+                    },
+                    args: [],
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [{
+                            name: 'N_RETURN_STATEMENT',
+                            expression: {
+                                name: 'N_INTEGER',
+                                number: 21
+                            }
+                        }]
+                    }
+                }, {
+                    name: 'N_STATIC_METHOD_DEFINITION',
+                    modifier: 'final',
+                    visibility: 'protected',
+                    method: {
+                        name: 'N_STRING',
+                        string: 'myStaticMethod'
+                    },
+                    args: [],
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [{
+                            name: 'N_RETURN_STATEMENT',
+                            expression: {
+                                name: 'N_INTEGER',
+                                number: 101
+                            }
+                        }]
+                    }
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            '(function () {' +
+            'var currentClass = namespace.defineClass("MyClass", {' +
+            'superClass: null, ' +
+            'interfaces: [], ' +
+            'staticProperties: {}, ' +
+            'properties: {}, ' +
+            'methods: {' +
+            '"myInstanceMethod": {' +
+            'isStatic: false, method: function _myInstanceMethod() {' +
+            'var scope = this;' +
+            'return tools.valueFactory.createInteger(21);' +
+            '}}, ' +
+            '"myStaticMethod": {' +
+            'isStatic: true, method: function _myStaticMethod() {' +
+            'var scope = this;' +
+            'return tools.valueFactory.createInteger(101);' +
+            '}}' +
+            '}, ' +
+            'constants: {}' +
+            '}, namespaceScope);' +
+            '}());' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/statements/constantTest.js
+++ b/test/integration/transpiler/statements/constantTest.js
@@ -10,8 +10,7 @@
 'use strict';
 
 var expect = require('chai').expect,
-    phpToJS = require('../../../..'),
-    PHPFatalError = require('phpcommon').PHPFatalError;
+    phpToJS = require('../../../..');
 
 describe('Transpiler "const" declaration statement test', function () {
     it('should correctly transpile multiple constant declarations in one statement', function () {

--- a/test/integration/transpiler/statements/constantTest.js
+++ b/test/integration/transpiler/statements/constantTest.js
@@ -1,0 +1,47 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..'),
+    PHPFatalError = require('phpcommon').PHPFatalError;
+
+describe('Transpiler "const" declaration statement test', function () {
+    it('should correctly transpile multiple constant declarations in one statement', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CONSTANT_STATEMENT',
+                constants: [{
+                    constant: 'FIRST_CONST',
+                    value: {
+                        name: 'N_INTEGER',
+                        number: '101'
+                    }
+                }, {
+                    constant: 'SECOND_CONST',
+                    value: {
+                        name: 'N_STRING_LITERAL',
+                        string: 'hello world!'
+                    }
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'namespace.defineConstant("FIRST_CONST", tools.valueFactory.createInteger(101));' +
+            'namespace.defineConstant("SECOND_CONST", tools.valueFactory.createString("hello world!"));' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/statements/continueTest.js
+++ b/test/integration/transpiler/statements/continueTest.js
@@ -257,7 +257,10 @@ describe('Transpiler "continue" statement test', function () {
 
         expect(function () {
             phpToJS.transpile(ast, {path: 'my_module.php'});
-        }).to.throw(PHPFatalError, '\'continue\' operator accepts only positive numbers in my_module.php on line 7');
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: \'continue\' operator accepts only positive integers in my_module.php on line 7'
+        );
     });
 
     it('should throw a fatal error when negative one is given as the continue level', function () {
@@ -277,38 +280,44 @@ describe('Transpiler "continue" statement test', function () {
 
         expect(function () {
             phpToJS.transpile(ast, {path: 'their_module.php'});
-        }).to.throw(PHPFatalError, '\'continue\' operator accepts only positive numbers in their_module.php on line 4');
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: \'continue\' operator with non-integer operand is no longer supported in their_module.php on line 4'
+        );
     });
 
-    it('should throw a runtime fatal error when not inside a looping structure for 1 level', function () {
+    it('should throw a compile time fatal error when not inside a looping structure for 1 level', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_CONTINUE_STATEMENT',
                 levels: {
                     name: 'N_INTEGER',
-                    number: 1
-                }
-            }]
+                    number: 1,
+                    bounds: {start: {line: 5, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
-        expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'tools.throwCannotBreakOrContinue(1);' +
-            'return tools.valueFactory.createNull();' +
-            '});'
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/my/my_module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: \'continue\' not in the \'loop\' or \'switch\' context in /my/my_module.php on line 5'
         );
     });
 
-    it('should throw a runtime fatal error when code is not enough levels deep', function () {
+    it('should throw a compile time fatal error when code is not enough levels deep', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_WHILE_STATEMENT',
                 condition: {
                     name: 'N_INTEGER',
-                    number: 21
+                    number: 21,
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
@@ -316,21 +325,23 @@ describe('Transpiler "continue" statement test', function () {
                         name: 'N_CONTINUE_STATEMENT',
                         levels: {
                             name: 'N_INTEGER',
-                            number: 2
-                        }
-                    }]
-                }
-            }]
+                            number: 2,
+                            bounds: {start: {line: 8, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
-        expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: while (tools.valueFactory.createInteger(21).coerceToBoolean().getNative()) {' +
-            'tools.throwCannotBreakOrContinue(2);' +
-            '}' +
-            'return tools.valueFactory.createNull();' +
-            '});'
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/your/your_module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: Cannot \'continue\' 2 levels in /your/your_module.php on line 8'
         );
     });
 });

--- a/test/integration/transpiler/statements/continueTest.js
+++ b/test/integration/transpiler/statements/continueTest.js
@@ -247,14 +247,17 @@ describe('Transpiler "continue" statement test', function () {
                 name: 'N_CONTINUE_STATEMENT',
                 levels: {
                     name: 'N_INTEGER',
-                    number: 0
-                }
-            }]
+                    number: 0,
+                    bounds: {start: {line: 7, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'continue\' operator accepts only positive numbers');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'continue\' operator accepts only positive numbers in my_module.php on line 7');
     });
 
     it('should throw a fatal error when negative one is given as the continue level', function () {
@@ -264,14 +267,17 @@ describe('Transpiler "continue" statement test', function () {
                 name: 'N_CONTINUE_STATEMENT',
                 levels: {
                     name: 'N_INTEGER',
-                    number: -1
-                }
-            }]
+                    number: -1,
+                    bounds: {start: {line: 4, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'continue\' operator accepts only positive numbers');
+            phpToJS.transpile(ast, {path: 'their_module.php'});
+        }).to.throw(PHPFatalError, '\'continue\' operator accepts only positive numbers in their_module.php on line 4');
     });
 
     it('should throw a runtime fatal error when not inside a looping structure for 1 level', function () {

--- a/test/integration/transpiler/statements/functionTest.js
+++ b/test/integration/transpiler/statements/functionTest.js
@@ -10,7 +10,9 @@
 'use strict';
 
 var expect = require('chai').expect,
-    phpToJS = require('../../../..');
+    phpCommon = require('phpcommon'),
+    phpToJS = require('../../../..'),
+    PHPFatalError = phpCommon.PHPFatalError;
 
 describe('Transpiler function statement test', function () {
     it('should correctly transpile an empty function in default (async) mode', function () {
@@ -39,7 +41,7 @@ describe('Transpiler function statement test', function () {
         );
     });
 
-    it('should correctly transpile a function with a by-reference parameter in default (async) mode', function () {
+    it('should correctly transpile a function with four by-reference parameters in default (async) mode', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -50,12 +52,51 @@ describe('Transpiler function statement test', function () {
                 },
                 args: [{
                     name: 'N_ARGUMENT',
-                    type: 'array',
+                    type: {
+                        name: 'N_ARRAY_TYPE'
+                    },
                     variable: {
                         name: 'N_REFERENCE',
                         operand: {
                             name: 'N_VARIABLE',
-                            variable: 'myByRefArg'
+                            variable: 'myByRefArrayArg'
+                        }
+                    }
+                }, {
+                    name: 'N_ARGUMENT',
+                    type: {
+                        name: 'N_CALLABLE_TYPE'
+                    },
+                    variable: {
+                        name: 'N_REFERENCE',
+                        operand: {
+                            name: 'N_VARIABLE',
+                            variable: 'myByRefCallableArg'
+                        }
+                    }
+                }, {
+                    name: 'N_ARGUMENT',
+                    type: {
+                        name: 'N_CLASS_TYPE',
+                        className: 'My\\NS\\MyClass'
+                    },
+                    variable: {
+                        name: 'N_REFERENCE',
+                        operand: {
+                            name: 'N_VARIABLE',
+                            variable: 'myByRefClassArg'
+                        }
+                    }
+                }, {
+                    name: 'N_ARGUMENT',
+                    type: {
+                        name: 'N_ITERABLE_TYPE'
+                    },
+                    variable: {
+                        name: 'N_REFERENCE',
+                        operand: {
+                            name: 'N_VARIABLE',
+                            variable: 'myByRefIterableArg'
                         }
                     }
                 }],
@@ -69,12 +110,188 @@ describe('Transpiler function statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
             'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("gogo", function _gogo($myByRefArg) {' +
+            'namespace.defineFunction("gogo", function _gogo($myByRefArrayArg, $myByRefCallableArg, $myByRefClassArg, $myByRefIterableArg) {' +
             'var scope = this;' +
-            'scope.getVariable("myByRefArg").setReference($myByRefArg.getReference());' +
-            '}, namespaceScope);' +
+            'scope.getVariable("myByRefArrayArg").setReference($myByRefArrayArg.getReference());' +
+            'scope.getVariable("myByRefCallableArg").setReference($myByRefCallableArg.getReference());' +
+            'scope.getVariable("myByRefClassArg").setReference($myByRefClassArg.getReference());' +
+            'scope.getVariable("myByRefIterableArg").setReference($myByRefIterableArg.getReference());' +
+            '}, namespaceScope, [' +
+            '{"type":"array","name":"myByRefArrayArg","ref":true},' +
+            '{"type":"callable","name":"myByRefCallableArg","ref":true},' +
+            '{"type":"class","className":"My\\\\NS\\\\MyClass","name":"myByRefClassArg","ref":true},' +
+            '{"type":"iterable","name":"myByRefIterableArg","ref":true}' +
+            ']);' +
             'return tools.valueFactory.createNull();' +
             '});'
+        );
+    });
+
+    it('should allow defining __autoload with no arguments if it is inside a namespace', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\Space',
+                statements: [{
+                    name: 'N_FUNCTION_STATEMENT',
+                    func: {
+                        name: 'N_STRING',
+                        string: '__autoload'
+                    },
+                    args: [],
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [{
+                            name: 'N_RETURN_STATEMENT',
+                            expression: {
+                                name: 'N_INTEGER',
+                                number: 1234
+                            }
+                        }]
+                    }
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'if (namespaceResult = (function (globalNamespace) {' +
+            'var namespace = globalNamespace.getDescendant("This\\\\Is\\\\My\\\\Space"), namespaceScope = tools.createNamespaceScope(namespace);' +
+            'namespace.defineFunction("__autoload", ' +
+            'function ___autoload() {var scope = this;' +
+            'return tools.valueFactory.createInteger(1234);' +
+            '}, namespaceScope);' +
+            '}(namespace))) { return namespaceResult; }' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should raise a fatal error on attempting to define __autoload with no arguments', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_FUNCTION_STATEMENT',
+                func: {
+                    name: 'N_STRING',
+                    string: '__autoload',
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                args: [],
+                body: {
+                    name: 'N_COMPOUND_STATEMENT',
+                    statements: [{
+                        name: 'N_RETURN_STATEMENT',
+                        expression: {
+                            name: 'N_INTEGER',
+                            number: 1234,
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                // Line reported should be that of the function statement itself
+                bounds: {start: {line: 7, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }.bind(this)).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: __autoload() must take exactly 1 argument in my_module.php on line 7'
+        );
+    });
+
+    it('should raise a fatal error on attempting to define __autoload with mixed case and no arguments', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_FUNCTION_STATEMENT',
+                func: {
+                    name: 'N_STRING',
+                    string: '__AUTolOad',
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                args: [],
+                body: {
+                    name: 'N_COMPOUND_STATEMENT',
+                    statements: [{
+                        name: 'N_RETURN_STATEMENT',
+                        expression: {
+                            name: 'N_INTEGER',
+                            number: 1234,
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                // Line reported should be that of the function statement itself
+                bounds: {start: {line: 7, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }.bind(this)).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: __autoload() must take exactly 1 argument in my_module.php on line 7'
+        );
+    });
+
+    it('should raise a fatal error on attempting to define __autoload with two arguments', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_FUNCTION_STATEMENT',
+                func: {
+                    name: 'N_STRING',
+                    string: '__autoload',
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                args: [{
+                    name: 'N_ARGUMENT',
+                    variable: {
+                        name: 'N_VARIABLE',
+                        variable: 'arg1'
+                    }
+                }, {
+                    name: 'N_ARGUMENT',
+                    variable: {
+                        name: 'N_VARIABLE',
+                        variable: 'arg2'
+                    }
+                }],
+                body: {
+                    name: 'N_COMPOUND_STATEMENT',
+                    statements: [{
+                        name: 'N_RETURN_STATEMENT',
+                        expression: {
+                            name: 'N_INTEGER',
+                            number: 1234,
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                // Line reported should be that of the function statement itself
+                bounds: {start: {line: 9, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }.bind(this)).to.throw(
+            PHPFatalError,
+            'PHP Fatal error: __autoload() must take exactly 1 argument in my_module.php on line 9'
         );
     });
 });

--- a/test/integration/transpiler/statements/gotoTest.js
+++ b/test/integration/transpiler/statements/gotoTest.js
@@ -26,7 +26,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT', // Jump over the "... continue ..." echo
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -35,7 +38,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -79,7 +85,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -88,7 +97,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT', // Jump back to just before the "... continue ..." label indefinitely
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -122,7 +134,10 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -131,7 +146,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -140,7 +158,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -182,7 +203,10 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -191,7 +215,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -200,7 +227,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_goto_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_goto_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -259,7 +289,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'first_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'first_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -268,10 +301,16 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'second_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'second_label'
+                }
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'first_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'first_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -286,7 +325,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'second_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'second_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -366,7 +408,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'second_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'second_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -375,7 +420,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'first_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'first_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -389,7 +437,10 @@ describe('Transpiler "goto" statement test', function () {
                 }
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'second_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'second_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -398,7 +449,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'first_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'first_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -458,7 +512,10 @@ describe('Transpiler "goto" statement test', function () {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_GOTO_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
@@ -467,7 +524,10 @@ describe('Transpiler "goto" statement test', function () {
                         }]
                     }, {
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }]
                 }
             }]
@@ -507,7 +567,10 @@ describe('Transpiler "goto" statement test', function () {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_GOTO_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
@@ -516,7 +579,10 @@ describe('Transpiler "goto" statement test', function () {
                         }]
                     }, {
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }]
                 }
             }]
@@ -554,7 +620,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_unused_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_unused_label'
+                }
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
@@ -591,7 +660,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label'
+                }
             }, {
                 name: 'N_IF_STATEMENT',
                 condition: {
@@ -608,7 +680,10 @@ describe('Transpiler "goto" statement test', function () {
                         }]
                     }, {
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }]
                 }
             }]
@@ -651,7 +726,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label'
+                }
             }, {
                 name: 'N_IF_STATEMENT',
                 condition: {
@@ -678,7 +756,10 @@ describe('Transpiler "goto" statement test', function () {
                         }]
                     }, {
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }]
                 }
             }]
@@ -723,7 +804,10 @@ describe('Transpiler "goto" statement test', function () {
                 }]
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label'
+                }
             }, {
                 name: 'N_IF_STATEMENT',
                 condition: {
@@ -734,7 +818,10 @@ describe('Transpiler "goto" statement test', function () {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
@@ -743,7 +830,10 @@ describe('Transpiler "goto" statement test', function () {
                         }]
                     }, {
                         name: 'N_GOTO_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }]
                 }
             }]
@@ -791,7 +881,10 @@ describe('Transpiler "goto" statement test', function () {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_GOTO_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
@@ -800,7 +893,10 @@ describe('Transpiler "goto" statement test', function () {
                         }]
                     }, {
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
@@ -840,32 +936,48 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 8, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_WHILE_STATEMENT',
                 condition: {
                     name: 'N_VARIABLE',
-                    variable: 'myCondition'
+                    variable: 'myCondition',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
-            }]
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in my_module.php on line 8');
     });
 
     it('should throw a fatal error when attempting to jump backwards into a while loop', function () {
@@ -875,30 +987,46 @@ describe('Transpiler "goto" statement test', function () {
                 name: 'N_WHILE_STATEMENT',
                 condition: {
                     name: 'N_VARIABLE',
-                    variable: 'myCondition'
+                    variable: 'myCondition',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 6, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in my_module.php on line 6');
     });
 
     it('should throw a fatal error when attempting to jump forwards into a do..while loop', function () {
@@ -906,32 +1034,48 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 7, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_DO_WHILE_STATEMENT',
                 condition: {
                     name: 'N_VARIABLE',
-                    variable: 'myCondition'
+                    variable: 'myCondition',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
-            }]
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'your_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in your_module.php on line 7');
     });
 
     it('should throw a fatal error when attempting to jump backwards into a do..while loop', function () {
@@ -941,30 +1085,46 @@ describe('Transpiler "goto" statement test', function () {
                 name: 'N_DO_WHILE_STATEMENT',
                 condition: {
                     name: 'N_VARIABLE',
-                    variable: 'myCondition'
+                    variable: 'myCondition',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 4, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in my_module.php on line 4');
     });
 
     it('should throw a fatal error when attempting to jump forwards into a for loop', function () {
@@ -972,40 +1132,58 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 12, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_FOR_STATEMENT',
                 initializer: {
                     name: 'N_COMMA_EXPRESSION',
-                    expressions: []
+                    expressions: [],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 condition: {
                     name: 'N_COMMA_EXPRESSION',
-                    expressions: []
+                    expressions: [],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 update: {
                     name: 'N_COMMA_EXPRESSION',
-                    expressions: []
+                    expressions: [],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
-            }]
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'their_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in their_module.php on line 12');
     });
 
     it('should throw a fatal error when attempting to jump backwards into a for loop', function () {
@@ -1015,38 +1193,56 @@ describe('Transpiler "goto" statement test', function () {
                 name: 'N_FOR_STATEMENT',
                 initializer: {
                     name: 'N_COMMA_EXPRESSION',
-                    expressions: []
+                    expressions: [],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 condition: {
                     name: 'N_COMMA_EXPRESSION',
-                    expressions: []
+                    expressions: [],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 update: {
                     name: 'N_COMMA_EXPRESSION',
-                    expressions: []
+                    expressions: [],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 3, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in my_module.php on line 3');
     });
 
     it('should throw a fatal error when attempting to jump forwards into a foreach loop', function () {
@@ -1054,39 +1250,57 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 7, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_FOREACH_STATEMENT',
                 array: {
                     name: 'N_VARIABLE',
-                    variable: 'myArray'
+                    variable: 'myArray',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 value: {
                     name: 'N_REFERENCE',
                     operand: {
                         name: 'N_VARIABLE',
-                        variable: 'item'
-                    }
+                        variable: 'item',
+                        bounds: {start: {line: 1, column: 1}}
+                    },
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
-            }]
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'your_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in your_module.php on line 7');
     });
 
     it('should throw a fatal error when attempting to jump backwards into a foreach loop', function () {
@@ -1096,37 +1310,55 @@ describe('Transpiler "goto" statement test', function () {
                 name: 'N_FOREACH_STATEMENT',
                 array: {
                     name: 'N_VARIABLE',
-                    variable: 'myArray'
+                    variable: 'myArray',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 value: {
                     name: 'N_REFERENCE',
                     operand: {
                         name: 'N_VARIABLE',
-                        variable: 'item'
-                    }
+                        variable: 'item',
+                        bounds: {start: {line: 1, column: 1}}
+                    },
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 body: {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
-                    }]
-                }
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 7, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'your_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in your_module.php on line 7');
     });
 
     it('should throw a fatal error when attempting to jump forwards into a switch statement', function () {
@@ -1134,52 +1366,73 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 6, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_SWITCH_STATEMENT',
                 expression: {
                     name: 'N_EXPRESSION',
                     left: {
                         name: 'N_INTEGER',
-                        number: 21
+                        number: 21,
+                        bounds: {start: {line: 1, column: 1}}
                     },
                     right: [{
                         operator: '+',
                         operand: {
                             name: 'N_INTEGER',
-                            number: 6
+                            number: 6,
+                            bounds: {start: {line: 1, column: 1}}
                         }
-                    }]
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 cases: [{
                     name: 'N_CASE',
                     expression: {
                         name: 'N_INTEGER',
-                        number: 27
+                        number: 27,
+                        bounds: {start: {line: 1, column: 1}}
                     },
                     body: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_BREAK_STATEMENT',
                         levels: {
                             name: 'N_INTEGER',
-                            number: '1'
-                        }
-                    }]
-                }]
-            }]
+                            number: '1',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in my_module.php on line 6');
     });
 
     it('should throw a fatal error when attempting to jump backwards into a switch statement', function () {
@@ -1191,48 +1444,69 @@ describe('Transpiler "goto" statement test', function () {
                     name: 'N_EXPRESSION',
                     left: {
                         name: 'N_INTEGER',
-                        number: 21
+                        number: 21,
+                        bounds: {start: {line: 1, column: 1}}
                     },
                     right: [{
                         operator: '+',
                         operand: {
                             name: 'N_INTEGER',
-                            number: 6
+                            number: 6,
+                            bounds: {start: {line: 1, column: 1}}
                         }
-                    }]
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 cases: [{
                     name: 'N_CASE',
                     expression: {
                         name: 'N_INTEGER',
-                        number: 27
+                        number: 27,
+                        bounds: {start: {line: 1, column: 1}}
                     },
                     body: [{
                         name: 'N_LABEL_STATEMENT',
-                        label: 'my_label'
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_INTEGER',
-                            number: '4'
-                        }]
+                            number: '4',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_BREAK_STATEMENT',
                         levels: {
                             name: 'N_INTEGER',
-                            number: '1'
-                        }
-                    }]
-                }]
+                            number: '1',
+                            bounds: {start: {line: 1, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 8, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed');
+            phpToJS.transpile(ast, {path: 'the_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' into loop or switch statement is disallowed in the_module.php on line 8');
     });
 
     it('should throw a fatal error when the target label of the goto does not exist outside any function', function () {
@@ -1242,17 +1516,25 @@ describe('Transpiler "goto" statement test', function () {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
                     name: 'N_STRING_LITERAL',
-                    string: 'start'
-                }]
+                    string: 'start',
+                    bounds: {start: {line: 1, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_GOTO_STATEMENT',
-                label: 'my_undefined_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_undefined_label',
+                    bounds: {start: {line: 7, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' to undefined label \'my_undefined_label\'');
+            phpToJS.transpile(ast, {path: 'your_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' to undefined label \'my_undefined_label\' in your_module.php on line 7');
     });
 
     it('should throw a fatal error when the target label of the goto does not exist inside a function', function () {
@@ -1262,7 +1544,8 @@ describe('Transpiler "goto" statement test', function () {
                 name: 'N_FUNCTION_STATEMENT',
                 func: {
                     name: 'N_STRING',
-                    string: 'my_function'
+                    string: 'my_function',
+                    bounds: {start: {line: 1, column: 1}}
                 },
                 args: [],
                 body: {
@@ -1271,19 +1554,29 @@ describe('Transpiler "goto" statement test', function () {
                         name: 'N_ECHO_STATEMENT',
                         expressions: [{
                             name: 'N_STRING_LITERAL',
-                            string: 'start'
-                        }]
+                            string: 'start',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
                     }, {
                         name: 'N_GOTO_STATEMENT',
-                        label: 'my_undefined_label'
-                    }]
-                }
-            }]
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_undefined_label',
+                            bounds: {start: {line: 4, column: 1}}
+                        },
+                        bounds: {start: {line: 1, column: 1}}
+                    }],
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, '\'goto\' to undefined label \'my_undefined_label\'');
+            phpToJS.transpile(ast, {path: 'my_module.php'});
+        }).to.throw(PHPFatalError, '\'goto\' to undefined label \'my_undefined_label\' in my_module.php on line 4');
     });
 
     it('should throw a fatal error when attempting to define a label twice', function () {
@@ -1291,21 +1584,35 @@ describe('Transpiler "goto" statement test', function () {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_label'
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 1, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_ECHO_STATEMENT',
                 expressions: [{
                     name: 'N_STRING_LITERAL',
-                    string: 'Hello world'
-                }]
+                    string: 'Hello world',
+                    bounds: {start: {line: 1, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
             }, {
                 name: 'N_LABEL_STATEMENT',
-                label: 'my_label'
-            }]
+                label: {
+                    name: 'N_STRING',
+                    string: 'my_label',
+                    bounds: {start: {line: 9, column: 1}}
+                },
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
         };
 
+        // NB: The line number quoted should be that of the second label found, not the first
         expect(function () {
-            phpToJS.transpile(ast);
-        }).to.throw(PHPFatalError, 'Label \'my_label\' already defined');
+            phpToJS.transpile(ast, {path: '/path/to/their_module.php'});
+        }).to.throw(PHPFatalError, 'Label \'my_label\' already defined in /path/to/their_module.php on line 9');
     });
 });

--- a/test/integration/transpiler/statements/ifStatementTest.js
+++ b/test/integration/transpiler/statements/ifStatementTest.js
@@ -96,7 +96,7 @@ describe('Transpiler if statement test', function () {
             '(tools.valueFactory.createBarewordString("myFunc").call([' +
             'tools.createClosure(function () {var scope = this;' +
             'if (scope.getVariable("myObject").getValue().getInstancePropertyByName(tools.valueFactory.createBarewordString("myProp")).getValue().coerceToBoolean().getNative()) {}' +
-            '}, scope)' +
+            '}, scope, namespaceScope)' +
             '], namespaceScope) || tools.valueFactory.createNull());' +
             'return tools.valueFactory.createNull();}'
         );

--- a/test/integration/transpiler/statements/interfaceTest.js
+++ b/test/integration/transpiler/statements/interfaceTest.js
@@ -41,7 +41,9 @@ describe('Transpiler interface statement test', function () {
                     visibility: 'public',
                     args: [{
                         name: 'N_ARGUMENT',
-                        type: 'array',
+                        type: {
+                            name: 'N_ARRAY_TYPE'
+                        },
                         variable: {
                             name: 'N_VARIABLE',
                             variable: 'someQueryArgs'
@@ -56,7 +58,9 @@ describe('Transpiler interface statement test', function () {
                     visibility: 'public',
                     args: [{
                         name: 'N_ARGUMENT',
-                        type: 'array',
+                        type: {
+                            name: 'N_ARRAY_TYPE'
+                        },
                         variable: {
                             name: 'N_VARIABLE',
                             variable: 'myBodyArgs'

--- a/test/integration/transpiler/statements/interfaceTest.js
+++ b/test/integration/transpiler/statements/interfaceTest.js
@@ -10,7 +10,9 @@
 'use strict';
 
 var expect = require('chai').expect,
-    phpToJS = require('../../../..');
+    phpCommon = require('phpcommon'),
+    phpToJS = require('../../../..'),
+    PHPFatalError = phpCommon.PHPFatalError;
 
 describe('Transpiler interface statement test', function () {
     it('should correctly transpile an interface in default (async) mode', function () {
@@ -84,6 +86,144 @@ describe('Transpiler interface statement test', function () {
             '}());' +
             'return tools.valueFactory.createNull();' +
             '});'
+        );
+    });
+
+    it('should throw a compile time fatal error when attempting to define an instance property inside an interface', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'Thing',
+                extend: [
+                    'A\\SuperClass'
+                ],
+                members: [{
+                    name: 'N_INSTANCE_PROPERTY_DEFINITION',
+                    visibility: 'private',
+                    variable: {
+                        name: 'N_VARIABLE',
+                        variable: 'myInvalidProp',
+                        bounds: {start: {line: 8, column: 1}}
+                    },
+                    bounds: {start: {line: 1, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/path/to/your_module.php'});
+        }).to.throw(PHPFatalError, 'Interfaces may not include member variables in /path/to/your_module.php on line 8');
+    });
+
+    it('should throw a compile time fatal error when attempting to define a static property inside an interface', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'Thing',
+                extend: [
+                    'A\\SuperClass'
+                ],
+                members: [{
+                    name: 'N_STATIC_PROPERTY_DEFINITION',
+                    visibility: 'private',
+                    variable: {
+                        name: 'N_VARIABLE',
+                        variable: 'firstProp',
+                        bounds: {start: {line: 7, column: 1}}
+                    },
+                    bounds: {start: {line: 1, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/path/to/the_module.php'});
+        }).to.throw(PHPFatalError, 'Interfaces may not include member variables in /path/to/the_module.php on line 7');
+    });
+
+    it('should throw a compile time fatal error when attempting to define an instance method body inside an interface', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'Thing',
+                extend: [
+                    'A\\SuperClass'
+                ],
+                members: [{
+                    name: 'N_METHOD_DEFINITION',
+                    visibility: 'public',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myMethod',
+                        bounds: {start: {line: 1, column: 1}}
+                    },
+                    args: [],
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [{
+                            name: 'N_RETURN_STATEMENT',
+                            bounds: {start: {line: 1, column: 1}}
+                        }],
+                        bounds: {start: {line: 1, column: 1}}
+                    },
+                    bounds: {start: {line: 7, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/path/to/module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'Fatal error: Interface function Thing::myMethod() cannot contain body in /path/to/module.php on line 7'
+        );
+    });
+
+    it('should throw a compile time fatal error when attempting to define a static method body inside an interface', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'Thing',
+                extend: [
+                    'A\\SuperClass'
+                ],
+                members: [{
+                    name: 'N_STATIC_METHOD_DEFINITION',
+                    method: {
+                        name: 'N_STRING',
+                        string: 'myMethod',
+                        bounds: {start: {line: 1, column: 1}}
+                    },
+                    modifier: 'final',
+                    visibility: 'protected',
+                    args: [],
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [],
+                        bounds: {start: {line: 1, column: 1}}
+                    },
+                    bounds: {start: {line: 9, column: 1}}
+                }],
+                bounds: {start: {line: 1, column: 1}}
+            }],
+            bounds: {start: {line: 1, column: 1}}
+        };
+
+        expect(function () {
+            phpToJS.transpile(ast, {path: '/path/to/module.php'});
+        }).to.throw(
+            PHPFatalError,
+            'Fatal error: Interface function Thing::myMethod() cannot contain body in /path/to/module.php on line 9'
         );
     });
 });

--- a/test/integration/transpiler/statements/staticTest.js
+++ b/test/integration/transpiler/statements/staticTest.js
@@ -24,6 +24,9 @@ describe('Transpiler static variable scope statement test', function () {
                 },
                 args: [{
                     name: 'N_ARGUMENT',
+                    type: {
+                        name: 'N_CALLABLE_TYPE'
+                    },
                     variable: {
                         name: 'N_VARIABLE',
                         variable: 'myArg'
@@ -61,7 +64,9 @@ describe('Transpiler static variable scope statement test', function () {
             'scope.getVariable("myArg").setValue($myArg.getValue());' +
             'scope.importStatic("firstVar");' +
             'scope.importStatic("secondVar", tools.valueFactory.createInteger(101));' +
-            '}, namespaceScope);' +
+            '}, namespaceScope, [' +
+            '{"type":"callable","name":"myArg"}' +
+            ']);' +
             'return tools.valueFactory.createNull();' +
             '});'
         );

--- a/test/unit/LabelRepositoryTest.js
+++ b/test/unit/LabelRepositoryTest.js
@@ -23,51 +23,53 @@ describe('LabelRepository', function () {
     describe('addGoto()', function () {
         describe('if it has not yet been found', function () {
             it('should mark the label as pending', function () {
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
 
                 expect(labelRepository.isPending('my_label')).to.be.true;
             });
 
             it('should not mark the label as found', function () {
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
 
                 expect(labelRepository.hasBeenFound('my_label')).to.be.false;
             });
 
-            it('should dispatch a "goto label" event', function () {
+            it('should dispatch a "goto label" event with the node', function () {
                 var listener = sinon.spy();
                 labelRepository.on('goto label', listener);
 
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
 
                 expect(listener).to.have.been.calledOnce;
+                expect(listener).to.have.been.calledWith({label: {string: 'my_label'}});
             });
         });
 
         describe('if it has already been found', function () {
             beforeEach(function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
             });
 
             it('should not mark the label as pending', function () {
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
 
                 expect(labelRepository.isPending('my_label')).to.be.false;
             });
 
             it('should not unmark the label as found', function () {
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
 
                 expect(labelRepository.hasBeenFound('my_label')).to.be.true;
             });
 
-            it('should still dispatch a "goto label" event', function () {
+            it('should still dispatch a "goto label" event with the node', function () {
                 var listener = sinon.spy();
                 labelRepository.on('goto label', listener);
 
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
 
                 expect(listener).to.have.been.calledOnce;
+                expect(listener).to.have.been.calledWith({label: {string: 'my_label'}});
             });
         });
     });
@@ -75,79 +77,99 @@ describe('LabelRepository', function () {
     describe('found()', function () {
         describe('if it has not yet been found nor is pending', function () {
             it('should mark the label as found', function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(labelRepository.hasBeenFound('my_label')).to.be.true;
             });
 
             it('should not mark the label as pending', function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(labelRepository.isPending('my_label')).to.be.false;
             });
 
-            it('should dispatch a "found label" event', function () {
+            it('should dispatch a "found label" event with the node', function () {
                 var listener = sinon.spy();
                 labelRepository.on('found label', listener);
 
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(listener).to.have.been.calledOnce;
+                expect(listener).to.have.been.calledWith({label: {string: 'my_label'}});
             });
         });
 
         describe('if it is pending', function () {
             beforeEach(function () {
-                labelRepository.addGoto('my_label');
+                labelRepository.addGoto({label: {string: 'my_label'}});
             });
 
             it('should mark the label as found', function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(labelRepository.hasBeenFound('my_label')).to.be.true;
             });
 
             it('should unmark the label as pending', function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(labelRepository.isPending('my_label')).to.be.false;
             });
 
-            it('should dispatch a "found label" event', function () {
+            it('should dispatch a "found label" event with the node', function () {
                 var listener = sinon.spy();
                 labelRepository.on('found label', listener);
 
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(listener).to.have.been.calledOnce;
+                expect(listener).to.have.been.calledWith({label: {string: 'my_label'}});
             });
         });
 
         describe('if it has already been found', function () {
             beforeEach(function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
             });
 
             it('should not unmark the label as found', function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(labelRepository.hasBeenFound('my_label')).to.be.true;
             });
 
             it('should not mark the label as pending', function () {
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(labelRepository.isPending('my_label')).to.be.false;
             });
 
-            it('should still dispatch a "found label" event', function () {
+            it('should still dispatch a "found label" event with the node', function () {
                 var listener = sinon.spy();
                 labelRepository.on('found label', listener);
 
-                labelRepository.found('my_label');
+                labelRepository.found({label: {string: 'my_label'}});
 
                 expect(listener).to.have.been.calledOnce;
+                expect(listener).to.have.been.calledWith({label: {string: 'my_label'}});
             });
+        });
+    });
+
+    describe('getFirstPendingLabelGotoNode()', function () {
+        it('should throw when there are no pending labels', function () {
+            expect(function () {
+                labelRepository.getFirstPendingLabelGotoNode();
+            }).to.throw('There are no pending labels');
+        });
+
+        it('should return the first pending label', function () {
+            labelRepository.found({label: {string: 'first_label'}});
+            labelRepository.addGoto({label: {string: 'second_label'}});
+            labelRepository.addGoto({label: {string: 'third_label'}});
+
+            expect(labelRepository.getFirstPendingLabelGotoNode())
+                .to.deep.equal({label: {string: 'second_label'}});
         });
     });
 
@@ -157,15 +179,15 @@ describe('LabelRepository', function () {
         });
 
         it('should return a list of both pending and found labels', function () {
-            labelRepository.addGoto('first_label');
-            labelRepository.found('second_label');
+            labelRepository.addGoto({label: {string: 'first_label'}});
+            labelRepository.found({label: {string: 'second_label'}});
 
             expect(labelRepository.getLabels()).to.deep.equal(['first_label', 'second_label']);
         });
 
         it('should only list pending labels once, regardless of their number of gotos', function () {
-            labelRepository.addGoto('my_label');
-            labelRepository.addGoto('my_label');
+            labelRepository.addGoto({label: {string: 'my_label'}});
+            labelRepository.addGoto({label: {string: 'my_label'}});
 
             expect(labelRepository.getLabels()).to.deep.equal(['my_label']);
         });
@@ -177,10 +199,25 @@ describe('LabelRepository', function () {
         });
 
         it('should include only pending labels', function () {
-            labelRepository.addGoto('first_label');
-            labelRepository.found('second_label');
+            labelRepository.addGoto({label: {string: 'first_label'}});
+            labelRepository.found({label: {string: 'second_label'}});
 
             expect(labelRepository.getPendingLabels()).to.deep.equal(['first_label']);
+        });
+    });
+
+    describe('getPendingLabelGotoNodes()', function () {
+        it('should return an empty array initially', function () {
+            expect(labelRepository.getPendingLabelGotoNodes()).to.deep.equal([]);
+        });
+
+        it('should include only pending labels', function () {
+            labelRepository.addGoto({label: {string: 'first_label'}});
+            labelRepository.found({label: {string: 'second_label'}});
+
+            expect(labelRepository.getPendingLabelGotoNodes()).to.deep.equal([
+                {label: {string: 'first_label'}}
+            ]);
         });
     });
 
@@ -190,23 +227,25 @@ describe('LabelRepository', function () {
         });
 
         it('should include only pending labels', function () {
-            labelRepository.addGoto('first_label');
-            labelRepository.found('second_label');
+            labelRepository.addGoto({label: {string: 'first_label'}});
+            labelRepository.found({label: {string: 'second_label'}});
 
-            expect(labelRepository.getPendingLabelsHash()).to.deep.equal({'first_label': true});
+            expect(labelRepository.getPendingLabelsHash()).to.deep.equal({
+                'first_label': {label: {string: 'first_label'}}
+            });
         });
     });
 
     describe('hasBeenFound()', function () {
         it('should return true for a label that has been found but has no goto', function () {
-            labelRepository.found('my_label');
+            labelRepository.found({label: {string: 'my_label'}});
 
             expect(labelRepository.hasBeenFound('my_label')).to.be.true;
         });
 
         it('should return true for a label that has been found and has a goto', function () {
-            labelRepository.found('my_label');
-            labelRepository.addGoto('my_label');
+            labelRepository.found({label: {string: 'my_label'}});
+            labelRepository.addGoto({label: {string: 'my_label'}});
 
             expect(labelRepository.hasBeenFound('my_label')).to.be.true;
         });
@@ -216,7 +255,7 @@ describe('LabelRepository', function () {
         });
 
         it('should return false for a label that has a goto but has not been found', function () {
-            labelRepository.addGoto('my_label');
+            labelRepository.addGoto({label: {string: 'my_label'}});
 
             expect(labelRepository.hasBeenFound('my_label')).to.be.false;
         });
@@ -228,13 +267,13 @@ describe('LabelRepository', function () {
         });
 
         it('should return true when there is a pending label', function () {
-            labelRepository.addGoto('my_label');
+            labelRepository.addGoto({label: {string: 'my_label'}});
 
             expect(labelRepository.hasPending()).to.be.true;
         });
 
         it('should return false when there is only a found label', function () {
-            labelRepository.found('my_label');
+            labelRepository.found({label: {string: 'my_label'}});
 
             expect(labelRepository.hasPending()).to.be.false;
         });
@@ -246,13 +285,13 @@ describe('LabelRepository', function () {
         });
 
         it('should return true for a pending label', function () {
-            labelRepository.addGoto('my_label');
+            labelRepository.addGoto({label: {string: 'my_label'}});
 
             expect(labelRepository.isPending('my_label')).to.be.true;
         });
 
         it('should return false for a found label', function () {
-            labelRepository.found('my_label');
+            labelRepository.found({label: {string: 'my_label'}});
 
             expect(labelRepository.isPending('my_label')).to.be.false;
         });
@@ -264,7 +303,7 @@ describe('LabelRepository', function () {
             labelRepository.on('goto label', listener);
 
             labelRepository.off('goto label', listener);
-            labelRepository.addGoto('my_label');
+            labelRepository.addGoto({label: {string: 'my_label'}});
 
             expect(listener).not.to.have.been.called;
         });


### PR DESCRIPTION
- Use a `Translator` from PHPCommon for error message handling and add file and line number info
- Add PHP 7-style `Throwable` handling and parameter type checking
- Add support for PHP `const ...;` statement
