### PR TITLE
Add support for transpiling PHP "clone" operator

### DIFF
--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -690,6 +690,12 @@ module.exports = {
         'N_CLASS_TYPE': function (node) {
             return '"type":"class","className":' + JSON.stringify(node.className);
         },
+        'N_CLONE_EXPRESSION': function (node, interpret, context) {
+            return context.createExpressionSourceNode(
+                [interpret(node.operand, {getValue: true}), '.clone()'],
+                node
+            );
+        },
         'N_CLOSURE': function (node, interpret, context) {
             var func = interpretFunction(null, node.args, node.bindings, node.body, interpret, context),
                 extraArgChunks = buildExtraFunctionDefinitionArgChunks([

--- a/test/integration/transpiler/operators/cloneTest.js
+++ b/test/integration/transpiler/operators/cloneTest.js
@@ -1,0 +1,39 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler clone operator test', function () {
+    it('should correctly transpile a return of a cloned variable', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_CLONE_EXPRESSION',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myObject'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return scope.getVariable("myObject").getValue().clone();' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+});


### PR DESCRIPTION
Transpiles use of the PHP `clone ...` operator to the new `Value.prototype.clone()` method in PHPCore.