### PR TITLE
Improvements related to parsing changes in PHPToAST

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+strategy:
+    matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            # Check out the repository under $GITHUB_WORKSPACE, so this job can access it
+            - uses: actions/checkout@v2
+
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+
+            - name: Install NPM dependencies
+              run: npm ci
+
+            - name: Run tests
+              run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,13 +2,14 @@ name: CI
 
 on: [push, pull_request]
 
-strategy:
-    matrix:
-        node-version: [8.x, 10.x, 12.x]
-
 jobs:
     build:
         runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [8.x, 10.x, 12.x]
+
         steps:
             # Check out the repository under $GITHUB_WORKSPACE, so this job can access it
             - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-
-node_js:
-    - "8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,9 +337,9 @@
           "dev": true
         },
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -382,22 +382,22 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -539,9 +539,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -578,9 +578,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -664,9 +664,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-date-object": {
@@ -703,12 +703,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -743,9 +743,9 @@
       }
     },
     "jshint": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
-      "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.1.tgz",
+      "integrity": "sha512-WXWePB8ssAH3DlD05IoqolsY6arhbll/1+i2JkRPpihQAuiNaR/gSt8VKIcxpV5m6XChP0hCwESQUqpuQMA8Tg==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
@@ -802,9 +802,9 @@
       "dev": true
     },
     "microdash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.3.0.tgz",
-      "integrity": "sha1-TQ0yKY1UllS9lIhGAzkzqBwdkjs="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.1.tgz",
+      "integrity": "sha512-NJz1FkkTucluPbIzxkuLutzFTI3WWGJ8iOBAJIO49oHK19YkAOR/q8/XASiYS8J8OK8zGpxSD6/j/+M90gqdsQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -822,18 +822,18 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -849,7 +849,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
+        "mkdirp": "0.5.5",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -965,9 +965,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -1008,9 +1008,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -1068,9 +1068,9 @@
       }
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "readable-stream": {
@@ -1177,24 +1177,24 @@
         "strip-ansi": "^4.0.0"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -743,19 +743,27 @@
       }
     },
     "jshint": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.1.tgz",
-      "integrity": "sha512-WXWePB8ssAH3DlD05IoqolsY6arhbll/1+i2JkRPpihQAuiNaR/gSt8VKIcxpV5m6XChP0hCwESQUqpuQMA8Tg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
+      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "~4.17.11",
+        "lodash": "~4.17.19",
         "minimatch": "~3.0.2",
         "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        }
       }
     },
     "just-extend": {
@@ -775,9 +783,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.get": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "jshint": "^2.11.1",
+    "jshint": "^2.12.0",
     "mocha": "^7.2.0",
     "nowdoc": "^1.0.1",
     "sinon": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "es6-set": "^0.1.5",
-    "microdash": "~1",
+    "microdash": "^1.4.1",
     "phpcommon": "^2.0.0",
     "source-map": "^0.5.6",
     "source-map-to-comment": "^1.1.0",
@@ -32,8 +32,8 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "jshint": "^2.10.2",
-    "mocha": "^7.1.1",
+    "jshint": "^2.11.1",
+    "mocha": "^7.2.0",
     "nowdoc": "^1.0.1",
     "sinon": "^5.1.1",
     "sinon-chai": "^3.3.0"

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -14,6 +14,7 @@ var _ = require('microdash'),
     MODE = 'mode',
     PATH = 'path',
     PREFIX = 'prefix',
+    RETURN_SOURCE_MAP = 'returnMap',
     RUNTIME_PATH = 'runtimePath',
     SOURCE_CONTENT = 'sourceContent',
     SOURCE_MAP = 'sourceMap',
@@ -1918,9 +1919,20 @@ module.exports = {
                     sourceMap.setSourceContent(filePath, sourceMapOptions[SOURCE_CONTENT]);
                 }
 
+                compiledSourceMap = sourceMap.toStringWithSourceMap();
+
+                if (sourceMapOptions[RETURN_SOURCE_MAP]) {
+                    // Return the source map data object rather than embedding it in a comment,
+                    // much more efficient when we need to hand the source map data off
+                    // to the next processor in a chain, eg. for Webpack when used with PHPify
+                    return {
+                        code: compiledSourceMap.code,
+                        map: compiledSourceMap.map.toJSON() // Data object, not actually stringified to JSON
+                    };
+                }
+
                 // Append a source map comment containing the entire source map data as a data: URI,
                 // in the form `//# sourceMappingURL=data:application/json;base64,...`
-                compiledSourceMap = sourceMap.toStringWithSourceMap();
                 compiledBody = compiledSourceMap.code + '\n\n' +
                     sourceMapToComment(compiledSourceMap.map.toJSON()) + '\n';
             } else {

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -1684,6 +1684,7 @@ module.exports = {
                      * @param {string} translationKey
                      * @param {object} node
                      * @param {Object.<String, string>=} placeholderVariables
+                     * @throws {PHPFatalError}
                      */
                     raiseError: function (translationKey, node, placeholderVariables) {
                         var message = translator.translate(translationKey, placeholderVariables),

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -659,11 +659,13 @@ module.exports = {
 
                     methodCodeChunks.push('"' + data.name + '": ', data.body);
                 } else if (member.name === 'N_CONSTANT_DEFINITION') {
-                    if (constantCodeChunks.length > 0) {
-                        constantCodeChunks.push(', ');
-                    }
+                    _.each(data, function (constant) {
+                        if (constantCodeChunks.length > 0) {
+                            constantCodeChunks.push(', ');
+                        }
 
-                    constantCodeChunks.push('"' + data.name + '": ', data.value);
+                        constantCodeChunks.push('"' + constant.name + '": ', constant.value);
+                    });
                 }
             });
 
@@ -729,13 +731,15 @@ module.exports = {
             return context.createInternalSourceNode(processBlock(node.statements, interpret, context), node);
         },
         'N_CONSTANT_DEFINITION': function (node, interpret, context) {
-            return {
-                name: node.constant,
-                value: context.createInternalSourceNode(
-                    ['function () { return '].concat(interpret(node.value, {isConstantOrProperty: true}), '; }'),
-                    node
-                )
-            };
+            return node.constants.map(function (constant) {
+                return {
+                    name: constant.constant,
+                    value: context.createInternalSourceNode(
+                        ['function () { return '].concat(interpret(constant.value, {isConstantOrProperty: true}), '; }'),
+                        constant
+                    )
+                };
+            });
         },
         'N_CONSTANT_STATEMENT': function (node, interpret, context) {
             var codeChunks = [];
@@ -1343,11 +1347,18 @@ module.exports = {
 
                     methodCodeChunks.push(context.createInternalSourceNode(['"' + data.name + '": '].concat(data.body), member));
                 } else if (member.name === 'N_CONSTANT_DEFINITION') {
-                    if (constantCodeChunks.length > 0) {
-                        constantCodeChunks.push(', ');
-                    }
+                    _.each(data, function (constant) {
+                        if (constantCodeChunks.length > 0) {
+                            constantCodeChunks.push(', ');
+                        }
 
-                    constantCodeChunks.push(context.createInternalSourceNode(['"' + data.name + '": '].concat(data.value), member));
+                        constantCodeChunks.push(
+                            context.createInternalSourceNode(
+                                ['"' + constant.name + '": '].concat(constant.value),
+                                member
+                            )
+                        );
+                    });
                 }
             });
 

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -690,6 +690,12 @@ module.exports = {
         'N_CLASS_TYPE': function (node) {
             return '"type":"class","className":' + JSON.stringify(node.className);
         },
+        'N_CLONE_EXPRESSION': function (node, interpret, context) {
+            return context.createExpressionSourceNode(
+                [interpret(node.operand, {getValue: true}), '.clone()'],
+                node
+            );
+        },
         'N_CLOSURE': function (node, interpret, context) {
             var func = interpretFunction(null, node.args, node.bindings, node.body, interpret, context),
                 extraArgChunks = buildExtraFunctionDefinitionArgChunks([

--- a/test/integration/transpiler/constructs/parentKeywordTest.js
+++ b/test/integration/transpiler/constructs/parentKeywordTest.js
@@ -48,14 +48,16 @@ describe('Transpiler parent:: construct expression test', function () {
                 className: 'MyClass',
                 members: [{
                     name: 'N_CONSTANT_DEFINITION',
-                    constant: 'MY_CONST',
-                    value: {
-                        name: 'N_CLASS_CONSTANT',
-                        className: {
-                            name: 'N_PARENT'
-                        },
-                        constant: 'PARENT_CONST'
-                    }
+                    constants: [{
+                        constant: 'MY_CONST',
+                        value: {
+                            name: 'N_CLASS_CONSTANT',
+                            className: {
+                                name: 'N_PARENT'
+                            },
+                            constant: 'PARENT_CONST'
+                        }
+                    }]
                 }]
             }]
         };

--- a/test/integration/transpiler/operators/cloneTest.js
+++ b/test/integration/transpiler/operators/cloneTest.js
@@ -1,0 +1,39 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler clone operator test', function () {
+    it('should correctly transpile a return of a cloned variable', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_CLONE_EXPRESSION',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myObject'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return scope.getVariable("myObject").getValue().clone();' +
+            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/sourceMapTest.js
+++ b/test/integration/transpiler/sourceMapTest.js
@@ -62,6 +62,63 @@ describe('Transpiler source map test', function () {
         );
     });
 
+    it('should correctly transpile a simple return statement in default (async) mode wih returnMap option', function () {
+        var ast = {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: '4',
+                        bounds: {
+                            start: {
+                                line: 8,
+                                column: 20
+                            }
+                        }
+                    },
+                    bounds: {
+                        start: {
+                            line: 8,
+                            column: 10
+                        }
+                    }
+                }],
+                bounds: {
+                    start: {
+                        line: 4,
+                        column: 6
+                    }
+                }
+            },
+            options = {
+                path: 'my_module.php',
+                sourceMap: {
+                    returnMap: true,
+                    sourceContent: '<?php $this = "is my source PHP";'
+                }
+            };
+
+        expect(phpToJS.transpile(ast, options)).to.deep.equal({
+            code: 'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
+            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'return tools.valueFactory.createInteger(4);' +
+            'return tools.valueFactory.createNull();' +
+            '});',
+            map: {
+                mappings: 'uMAOS,OAAU,mCAAV,C',
+                names: [],
+                sources: [
+                    'my_module.php'
+                ],
+                sourcesContent: [
+                    '<?php $this = "is my source PHP";'
+                ],
+                version: 3
+            }
+        });
+    });
+
     it('should correctly transpile global code, functions, methods and closures with debug vars in default (async) mode', function () {
         var ast = {
                 name: 'N_PROGRAM',

--- a/test/integration/transpiler/statements/class/constantTest.js
+++ b/test/integration/transpiler/statements/class/constantTest.js
@@ -22,22 +22,33 @@ describe('Transpiler class statement with constants test', function () {
                 members: [
                     {
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'MY_CONST',
-                        value: {
-                            name: 'N_INTEGER',
-                            number: 1001
-                        }
+                        constants: [{
+                            constant: 'MY_CONST',
+                            value: {
+                                name: 'N_INTEGER',
+                                number: 1001
+                            }
+                        }]
                     },
                     {
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'ANOTHER_ONE',
-                        value: {
-                            name: 'N_CLASS_CONSTANT',
-                            className: {
-                                name: 'N_SELF'
-                            },
-                            constant: 'MY_CONST'
-                        }
+                        constants: [{
+                            constant: 'ANOTHER_ONE',
+                            value: {
+                                name: 'N_CLASS_CONSTANT',
+                                className: {
+                                    name: 'N_SELF'
+                                },
+                                constant: 'MY_CONST'
+                            }
+                        }, {
+                            // Also test one statement with two declarations (would be comma-separated)
+                            constant: 'YET_ANOTHER_ONE',
+                            value: {
+                                name: 'N_INTEGER',
+                                number: '1234'
+                            }
+                        }]
                     }
                 ]
             }]
@@ -59,6 +70,9 @@ describe('Transpiler class statement with constants test', function () {
             '}, ' +
             '"ANOTHER_ONE": function () { ' +
             'return currentClass.getConstantByName("MY_CONST", namespaceScope); ' +
+            '}, ' +
+            '"YET_ANOTHER_ONE": function () { ' +
+            'return tools.valueFactory.createInteger(1234); ' +
             '}' +
             '}' +
             '}, namespaceScope);' +

--- a/test/integration/transpiler/statements/class/propertyTest.js
+++ b/test/integration/transpiler/statements/class/propertyTest.js
@@ -124,11 +124,13 @@ describe('Transpiler class statement with properties test', function () {
                 members: [
                     {
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'MY_CONST',
-                        value: {
-                            name: 'N_INTEGER',
-                            number: 1001
-                        }
+                        constants: [{
+                            constant: 'MY_CONST',
+                            value: {
+                                name: 'N_INTEGER',
+                                number: 1001
+                            }
+                        }]
                     },
                     {
                         name: 'N_INSTANCE_PROPERTY_DEFINITION',
@@ -184,11 +186,13 @@ describe('Transpiler class statement with properties test', function () {
                 members: [
                     {
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'MY_CONST',
-                        value: {
-                            name: 'N_INTEGER',
-                            number: 1001
-                        }
+                        constants: [{
+                            constant: 'MY_CONST',
+                            value: {
+                                name: 'N_INTEGER',
+                                number: 1001
+                            }
+                        }]
                     },
                     {
                         name: 'N_STATIC_PROPERTY_DEFINITION',

--- a/test/integration/transpiler/statements/interfaceTest.js
+++ b/test/integration/transpiler/statements/interfaceTest.js
@@ -27,11 +27,20 @@ describe('Transpiler interface statement test', function () {
                 ],
                 members: [{
                     name: 'N_CONSTANT_DEFINITION',
-                    constant: 'SHAPE',
-                    value: {
-                        name: 'N_STRING_LITERAL',
-                        string: 'sphere'
-                    }
+                    constants: [{
+                        constant: 'SHAPE_ONE',
+                        value: {
+                            name: 'N_STRING_LITERAL',
+                            string: 'sphere'
+                        }
+                    }, {
+                        // Also test one statement with two declarations (would be comma-separated)
+                        constant: 'SHAPE_TWO',
+                        value: {
+                            name: 'N_STRING_LITERAL',
+                            string: 'circle'
+                        }
+                    }]
                 }, {
                     name: 'N_STATIC_INTERFACE_METHOD_DEFINITION',
                     method: {
@@ -84,7 +93,8 @@ describe('Transpiler interface statement test', function () {
             '"doSomethingElse": {isStatic: false, abstract: true}' +
             '}, ' +
             'constants: {' +
-            '"SHAPE": function () { return tools.valueFactory.createString("sphere"); }' +
+            '"SHAPE_ONE": function () { return tools.valueFactory.createString("sphere"); }, ' +
+            '"SHAPE_TWO": function () { return tools.valueFactory.createString("circle"); }' +
             '}' +
             '}, namespaceScope);' +
             '}());' +


### PR DESCRIPTION
- Allow class constant definitions to be comma-separated
- Add support for transpiling PHP `clone ...` operator (was previously parsed as a unary expression, but then its runtime handling was unimplemented - now fully supported)
- Add support for `returnMap` option, to allow a raw source map to be returned rather than being serialised into a source map comment. Used to optimise bundling as a bundler such as Webpack can then consume that raw source map rather than having to extract, decode and deserialise the comment.