### PR TITLE
Fix support for switch statements where the default case is not last

### DIFF
--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -1044,7 +1044,8 @@ module.exports = {
                          * allowing us to detect that the default case (which need not be the final one)
                          * should be used.
                          */
-                        switchExpressionVariable + ' === null',
+                        context.useCoreSymbol('switchDefault'),
+                        '(' + switchExpressionVariable + ')',
                         ') {',
                         bodyChunks,
                         '}'

--- a/test/integration/transpiler/statements/breakTest.js
+++ b/test/integration/transpiler/statements/breakTest.js
@@ -222,11 +222,11 @@ describe('Transpiler "break" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, switchCase = core.switchCase, switchOn = core.switchOn;' +
-            'block_1: {' +
             'var switchExpression_1 = switchOn(createInteger(21)), ' +
             'switchMatched_1 = false;' +
+            'block_1: {' +
             'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'break block_1;' +
             '}' +
             '}' +

--- a/test/integration/transpiler/statements/continueTest.js
+++ b/test/integration/transpiler/statements/continueTest.js
@@ -223,11 +223,11 @@ describe('Transpiler "continue" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, switchCase = core.switchCase, switchOn = core.switchOn;' +
-            'block_1: {' +
             'var switchExpression_1 = switchOn(createInteger(21)), ' +
             'switchMatched_1 = false;' +
+            'block_1: {' +
             'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'break block_1;' +
             '}' +
             '}' +

--- a/test/integration/transpiler/statements/switchTest.js
+++ b/test/integration/transpiler/statements/switchTest.js
@@ -306,7 +306,7 @@ describe('Transpiler "switch" statement test', function () {
 
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
-            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchDefault = core.switchDefault, switchOn = core.switchOn;' +
             'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
             'switchMatched_1 = false;' +
             'block_1: while (true) {' +
@@ -315,7 +315,7 @@ describe('Transpiler "switch" statement test', function () {
             'setValue(getVariable("a"), createInteger(7));' +
             'break block_1;' +
             '}' +
-            'if (switchMatched_1 || switchExpression_1 === null) {' +
+            'if (switchMatched_1 || switchDefault(switchExpression_1)) {' +
             'switchMatched_1 = true;' +
             'setValue(getVariable("a"), createInteger(8));' +
             '}' +

--- a/test/integration/transpiler/statements/switchTest.js
+++ b/test/integration/transpiler/statements/switchTest.js
@@ -13,7 +13,109 @@ var expect = require('chai').expect,
     phpToJS = require('../../../..');
 
 describe('Transpiler "switch" statement test', function () {
-    it('should correctly transpile a switch with two cases and default in default (async) mode', function () {
+    it('should correctly transpile a switch with two cases and no default', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_SWITCH_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    right: [{
+                        operator: '+',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 6
+                        }
+                    }]
+                },
+                cases: [{
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 27
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '7'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }, {
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 101
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '10'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
+            'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
+            'switchMatched_1 = false;' +
+            'block_1: {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(7));' +
+            'break block_1;' +
+            '}' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(101))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(10));' +
+            'break block_1;' +
+            '}' +
+            '}' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a switch with one case and default with default as last', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -87,18 +189,142 @@ describe('Transpiler "switch" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
-            'block_1: {' +
             'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
             'switchMatched_1 = false;' +
+            'block_1: {' +
             'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'setValue(getVariable("a"), createInteger(7));' +
             'break block_1;' +
             '}' +
-            'if (!switchMatched_1) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'setValue(getVariable("a"), createInteger(8));' +
             '}' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a switch with two cases and default with default as second', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_SWITCH_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    right: [{
+                        operator: '+',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 6
+                        }
+                    }]
+                },
+                cases: [{
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 101
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '7'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }, {
+                    name: 'N_DEFAULT_CASE',
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '8'
+                                }
+                            }]
+                        }
+                    }]
+                }, {
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 27
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '1001'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
+            'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
+            'switchMatched_1 = false;' +
+            'block_1: while (true) {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(101))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(7));' +
+            'break block_1;' +
+            '}' +
+            'if (switchMatched_1 || switchExpression_1 === null) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(8));' +
+            '}' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(1001));' +
+            'break block_1;' +
+            '}' +
+            'if (switchMatched_1) {break;} else {switchExpression_1 = null;}' +
             '}' +
             '});'
         );


### PR DESCRIPTION
Fixes https://github.com/asmblah/uniter/issues/61.

`default` switch cases do not need to be last in the sequence. Due to fall-through behaviour, sorting cases in order to place the default case (if present) at the end is not a general solution.
Instead, all non-default cases are evaluated first - if none match and a default case is present, execution will jump back up to the default case.

Corresponding `phpcore` fix: https://github.com/uniter/phpcore/pull/11