### PR TITLE
Async mode & opcode refactor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [8.x, 10.x, 12.x]
+                node-version: [12.x, 14.x, 16.x]
 
         steps:
             # Check out the repository under $GITHUB_WORKSPACE, so this job can access it

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,55 +5,56 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "8.1.0",
+      "name": "phptojs",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "es6-set": "^0.1.5",
         "microdash": "^1.4.2",
-        "phpcommon": "^2.0.0",
-        "source-map": "^0.5.6",
-        "source-map-to-comment": "^1.1.0",
+        "phpcommon": "^2.0.1",
+        "source-map": "^0.7.3",
+        "source-map-to-comment": "^2.0.0",
         "transpiler": "~1.2"
       },
       "devDependencies": {
-        "chai": "^4.2.0",
-        "jshint": "^2.12.0",
-        "mocha": "^7.2.0",
+        "chai": "^4.3.6",
+        "jshint": "^2.13.4",
+        "mocha": "^9.2.2",
         "nowdoc": "^1.0.1",
-        "sinon": "^5.1.1",
-        "sinon-chai": "^3.3.0"
+        "sinon": "^13.0.1",
+        "sinon-chai": "^3.7.0"
       },
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/@sinonjs/commons": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
-      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
+      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
       "dev": true,
       "dependencies": {
-        "samsam": "1.3.0"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
@@ -62,40 +63,49 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "node_modules/ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -106,18 +116,9 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
     "node_modules/assertion-error": {
@@ -130,9 +131,9 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "node_modules/binary-extensions": {
@@ -172,39 +173,30 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       },
       "engines": {
@@ -212,29 +204,31 @@
       }
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -247,25 +241,30 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
-        "glob-parent": "~5.1.0",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.6.0"
       },
       "engines": {
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.1.1"
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/cli": {
@@ -282,64 +281,32 @@
       }
     },
     "node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -358,9 +325,9 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "node_modules/d": {
@@ -379,22 +346,38 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/deep-eql": {
@@ -409,22 +392,10 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "dependencies": {
-        "object-keys": "^1.0.12"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
@@ -441,9 +412,9 @@
       }
     },
     "node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
       "dev": true,
       "funding": [
         {
@@ -487,9 +458,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "node_modules/entities": {
@@ -498,77 +469,18 @@
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
-    "node_modules/es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
-        "object-inspect": "^1.9.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-abstract/node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.58",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.58.tgz",
+      "integrity": "sha512-LHO+KBBaHGwjy32ibSaMY+ZzjpC4K4I5bPoijICMBL7gXEXfrEUrzssmNP+KigbQEp1dRUnGkry/vUnxOqptLQ==",
+      "hasInstallScript": true,
       "dependencies": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/es5-ext/node_modules/es6-symbol": {
@@ -611,26 +523,25 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true,
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=6"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/event-emitter": {
@@ -652,17 +563,17 @@
       }
     },
     "node_modules/ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "dependencies": {
-        "type": "^2.0.0"
+        "type": "^2.5.0"
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-      "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -677,25 +588,26 @@
       }
     },
     "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "dependencies": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
-      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
-      "dependencies": {
-        "is-buffer": "~2.0.3"
-      },
       "bin": {
         "flat": "cli.js"
       }
@@ -707,10 +619,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -720,12 +631,6 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -745,24 +650,10 @@
         "node": "*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -780,9 +671,9 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -800,37 +691,13 @@
         "node": ">=4.x"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=8"
       }
     },
     "node_modules/he": {
@@ -883,53 +750,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -940,36 +760,24 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -981,35 +789,25 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
-      },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=8"
       }
     },
-    "node_modules/is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.1"
-      },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -1025,31 +823,29 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jshint": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
-      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.4.tgz",
+      "integrity": "sha512-HO3bosL84b2qWqI0q+kpT/OpRJwo0R4ivgmxaO848+bo10rc50SkPnrtwSFXttW0ym4np8jbJvLwk5NziB7jIw==",
       "dev": true,
       "dependencies": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "~4.17.19",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2",
-        "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
       },
       "bin": {
@@ -1057,28 +853,30 @@
       }
     },
     "node_modules/just-extend": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
     "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.get": {
@@ -1088,22 +886,29 @@
       "dev": true
     },
     "node_modules/log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "dependencies": {
-        "chalk": "^2.4.2"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lolex": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-      "dev": true
+    "node_modules/loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
     },
     "node_modules/microdash": {
       "version": "1.4.2",
@@ -1114,9 +919,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1125,144 +930,107 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mocha": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
-      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "dependencies": {
-        "ansi-colors": "3.2.3",
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.3.0",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "3.0.0",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.5",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.6",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
-        "wide-align": "1.1.3",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
         "mocha": "bin/mocha"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
       }
     },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
       "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "brace-expansion": "^1.1.7"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nise": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
-      }
-    },
-    "node_modules/nise/node_modules/lolex": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/node-environment-flags": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-      "dev": true,
-      "dependencies": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
       }
     },
     "node_modules/normalize-path": {
@@ -1284,56 +1052,6 @@
         "template-string": "^1.1.0"
       }
     },
-    "node_modules/object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
-      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1344,48 +1062,42 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "dependencies": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^3.0.2"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -1416,11 +1128,11 @@
       }
     },
     "node_modules/phpcommon": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-2.0.0.tgz",
-      "integrity": "sha512-ZyJ6d9x5qh8RQRB0WTOhgtDBzCvLTtJNFNoM43HHZW9nTSqV3sUZZTwbua0ktvh5fne15huCNT9NJp2bl/0aTA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-2.0.1.tgz",
+      "integrity": "sha512-Rp3ThXJJCttXKDxphxriGv2CQYMjGT25NpkQpFtvEFvalgJ9yswPfI/PK39gFoiGE/94xhOx6um127DJiBLjVQ==",
       "dependencies": {
-        "microdash": "~1",
+        "microdash": "^1.4.1",
         "template-string": "~1"
       },
       "engines": {
@@ -1428,15 +1140,24 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/readable-stream": {
@@ -1452,15 +1173,15 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "dependencies": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.2.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=8.10.0"
       }
     },
     "node_modules/require-directory": {
@@ -1472,104 +1193,90 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "node_modules/samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
-      "dev": true
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "node_modules/shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/sinon": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
-      "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.4.2",
-        "nise": "^1.3.3",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/sinon-chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
-      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true,
       "peerDependencies": {
         "chai": "^4.0.0",
-        "sinon": ">=4.0.0 <10.0.0"
+        "sinon": ">=4.0.0"
       }
     },
     "node_modules/sinon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 8"
       }
     },
     "node_modules/source-map-to-comment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/source-map-to-comment/-/source-map-to-comment-1.1.0.tgz",
-      "integrity": "sha1-5RjEC8c5my4jyOMxoRY1qXdQ6cM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-to-comment/-/source-map-to-comment-2.0.0.tgz",
+      "integrity": "sha512-SJvZZ1t6mnLcxqV5w8JQoG8lFvp5ncMKMikYMxrUF87jaoqd+I1AaWMVX4Ot9kwsn68rfL2yu/0QcW60ZHeHgw==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -1578,54 +1285,29 @@
       "dev": true
     },
     "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -1641,15 +1323,18 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/template-string": {
@@ -1699,79 +1384,41 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+    "node_modules/workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "node": ">=10"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -1781,117 +1428,97 @@
       "dev": true
     },
     "node_modules/y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-      "dev": true
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
       "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "dependencies": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "node": ">=10"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
   "dependencies": {
     "@sinonjs/commons": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
-      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "@sinonjs/fake-timers": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
+      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "@sinonjs/text-encoding": {
@@ -1900,31 +1527,37 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       }
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -1932,18 +1565,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
     "assertion-error": {
@@ -1953,9 +1577,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "binary-extensions": {
@@ -1989,54 +1613,44 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
     "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
         "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -2048,19 +1662,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.6.0"
       }
     },
     "cli": {
@@ -2074,57 +1688,29 @@
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "concat-map": {
@@ -2143,9 +1729,9 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "d": {
@@ -2164,18 +1750,26 @@
       "dev": true
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
     "deep-eql": {
@@ -2187,19 +1781,10 @@
         "type-detect": "^4.0.0"
       }
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
     "dom-serializer": {
@@ -2213,9 +1798,9 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
-          "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
           "dev": true
         },
         "entities": {
@@ -2252,9 +1837,9 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "entities": {
@@ -2263,61 +1848,14 @@
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
-    "es-abstract": {
-      "version": "1.18.0-next.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-      "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.1",
-        "object-inspect": "^1.9.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.3",
-        "string.prototype.trimstart": "^1.0.3"
-      },
-      "dependencies": {
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        }
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.58",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.58.tgz",
+      "integrity": "sha512-LHO+KBBaHGwjy32ibSaMY+ZzjpC4K4I5bPoijICMBL7gXEXfrEUrzssmNP+KigbQEp1dRUnGkry/vUnxOqptLQ==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       },
       "dependencies": {
         "es6-symbol": {
@@ -2362,16 +1900,16 @@
         "es5-ext": "~0.10.14"
       }
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
     "event-emitter": {
@@ -2390,17 +1928,17 @@
       "dev": true
     },
     "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
       "requires": {
-        "type": "^2.0.0"
+        "type": "^2.5.0"
       },
       "dependencies": {
         "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
         }
       }
     },
@@ -2414,22 +1952,20 @@
       }
     },
     "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
       }
     },
     "flat": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
-      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2438,17 +1974,11 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -2462,21 +1992,10 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
-    "get-intrinsic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.0.tgz",
-      "integrity": "sha512-M11rgtQp5GZMZzDL7jLTNxbDfurpzuau5uqRWDPvlHjfvg3TdScAZo96GLvhMjImrmR8uAt0FS2RLoMrfWGKlg==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
-    },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2488,9 +2007,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -2502,25 +2021,10 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "he": {
@@ -2567,24 +2071,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-      "dev": true
-    },
-    "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2592,25 +2078,19 @@
       "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -2618,24 +2098,17 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.1"
-      }
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
     },
-    "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -2650,51 +2123,48 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jshint": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
-      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.4.tgz",
+      "integrity": "sha512-HO3bosL84b2qWqI0q+kpT/OpRJwo0R4ivgmxaO848+bo10rc50SkPnrtwSFXttW0ym4np8jbJvLwk5NziB7jIw==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "~4.17.19",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2",
-        "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
       }
     },
     "just-extend": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
-      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
     "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.get": {
@@ -2704,19 +2174,23 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       }
     },
-    "lolex": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-      "dev": true
+    "loupe": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "dev": true,
+      "requires": {
+        "get-func-name": "^2.0.0"
+      }
     },
     "microdash": {
       "version": "1.4.2",
@@ -2724,136 +2198,91 @@
       "integrity": "sha512-2R0iCltd/G5JKN3yCP9lgCbGLv+KpttUHIBW1Wfm7Mggbh3rsWEktHGsHHAGlGMjCYAvM+yL+eZgNxNGH6z+EQ=="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
     "mocha": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
-      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "requires": {
-        "ansi-colors": "3.2.3",
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.3.0",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "3.0.0",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.5",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.6",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
-        "wide-align": "1.1.3",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "4.2.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.1",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "workerpool": "6.2.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+        "minimatch": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "brace-expansion": "^1.1.7"
           }
         },
         "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
       }
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nise": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/formatio": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-          "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1",
-            "@sinonjs/samsam": "^3.1.0"
-          }
-        },
-        "lolex": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-          "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
-        }
-      }
-    },
-    "node-environment-flags": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-      "dev": true,
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
       }
     },
     "normalize-path": {
@@ -2872,41 +2301,6 @@
         "template-string": "^1.1.0"
       }
     },
-    "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
-      "integrity": "sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2917,33 +2311,27 @@
       }
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^0.1.0"
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^3.0.2"
       }
     },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true
     },
     "path-is-absolute": {
@@ -2968,19 +2356,28 @@
       "dev": true
     },
     "phpcommon": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-2.0.0.tgz",
-      "integrity": "sha512-ZyJ6d9x5qh8RQRB0WTOhgtDBzCvLTtJNFNoM43HHZW9nTSqV3sUZZTwbua0ktvh5fne15huCNT9NJp2bl/0aTA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-2.0.1.tgz",
+      "integrity": "sha512-Rp3ThXJJCttXKDxphxriGv2CQYMjGT25NpkQpFtvEFvalgJ9yswPfI/PK39gFoiGE/94xhOx6um127DJiBLjVQ==",
       "requires": {
-        "microdash": "~1",
+        "microdash": "^1.4.1",
         "template-string": "~1"
       }
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "readable-stream": {
       "version": "1.1.14",
@@ -2995,12 +2392,12 @@
       }
     },
     "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.2.1"
       }
     },
     "require-directory": {
@@ -3009,84 +2406,62 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
-    "shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-      "dev": true
-    },
-    "sinon": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.1.1.tgz",
-      "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.4.2",
-        "nise": "^1.3.3",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "randombytes": "^2.1.0"
+      }
+    },
+    "sinon": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
+      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
       },
       "dependencies": {
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
     "sinon-chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.5.0.tgz",
-      "integrity": "sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
       "dev": true,
       "requires": {}
     },
     "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
     },
     "source-map-to-comment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/source-map-to-comment/-/source-map-to-comment-1.1.0.tgz",
-      "integrity": "sha1-5RjEC8c5my4jyOMxoRY1qXdQ6cM="
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-to-comment/-/source-map-to-comment-2.0.0.tgz",
+      "integrity": "sha512-SJvZZ1t6mnLcxqV5w8JQoG8lFvp5ncMKMikYMxrUF87jaoqd+I1AaWMVX4Ot9kwsn68rfL2yu/0QcW60ZHeHgw=="
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -3095,42 +2470,23 @@
       "dev": true
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-json-comments": {
@@ -3140,12 +2496,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "template-string": {
@@ -3183,66 +2539,29 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+    "workerpool": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "wrappy": {
@@ -3252,77 +2571,49 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
     },
     "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
   "dependencies": {
     "es6-set": "^0.1.5",
     "microdash": "^1.4.2",
-    "phpcommon": "^2.0.0",
-    "source-map": "^0.5.6",
-    "source-map-to-comment": "^1.1.0",
+    "phpcommon": "^2.0.1",
+    "source-map": "^0.7.3",
+    "source-map-to-comment": "^2.0.0",
     "transpiler": "~1.2"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "jshint": "^2.12.0",
-    "mocha": "^7.2.0",
+    "chai": "^4.3.6",
+    "jshint": "^2.13.4",
+    "mocha": "^9.2.2",
     "nowdoc": "^1.0.1",
-    "sinon": "^5.1.1",
-    "sinon-chai": "^3.3.0"
+    "sinon": "^13.0.1",
+    "sinon-chai": "^3.7.0"
   },
   "engines": {
     "node": ">=0.6"

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -1044,7 +1044,8 @@ module.exports = {
                          * allowing us to detect that the default case (which need not be the final one)
                          * should be used.
                          */
-                        switchExpressionVariable + ' === null',
+                        context.useCoreSymbol('switchDefault'),
+                        '(' + switchExpressionVariable + ')',
                         ') {',
                         bodyChunks,
                         '}'

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -2518,7 +2518,7 @@ module.exports = {
         },
         'N_THROW_STATEMENT': function (node, interpret, context) {
             return context.createStatementSourceNode(
-                ['throw ', interpret(node.expression), ';'],
+                [context.useCoreSymbol('throw_'), '(', interpret(node.expression), ');'],
                 node
             );
         },

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -798,13 +798,13 @@ module.exports = {
             return '"type":"callable"';
         },
         'N_CASE': function (node, interpret, context) {
-            var bodyChunks = [],
+            var bodyChunks,
                 switchExpressionVariable = 'switchExpression_' + context.blockContexts.length,
                 switchMatchedVariable = 'switchMatched_' + context.blockContexts.length;
 
-            _.each(node.body, function (statement) {
-                bodyChunks.push(interpret(statement));
-            });
+            // Process the body of the case as a block (despite it technically not being braced)
+            // to allow for goto/label etc.
+            bodyChunks = processBlock(node.body, interpret, context, context.labelRepository);
 
             return context.createStatementSourceNode(
                 [
@@ -1035,9 +1035,9 @@ module.exports = {
                 switchMatchedVariable = 'switchMatched_' + blockContexts.length,
                 bodyChunks = [switchMatchedVariable + ' = true;'];
 
-            _.each(node.body, function (statement) {
-                bodyChunks.push(interpret(statement));
-            });
+            // Process the body of the case as a block (despite it technically not being braced)
+            // to allow for goto/label etc.
+            bodyChunks.push(processBlock(node.body, interpret, context, context.labelRepository));
 
             return context.createInternalSourceNode(
                 context.defaultCaseIsFinal ?

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -289,10 +289,9 @@ function interpretFunction(nameNode, argNodes, bindingNodes, statementNode, inte
         },
         subContext = {
             // This sub-context will be merged with the parent one,
-            // so we need to override any value for the `assignment` and `getValue` options
+            // so we need to override any value for the `assignment` option.
             assignment: undefined,
             blockContexts: [],
-            getValue: undefined,
             labelRepository: labelRepository,
             nextLoopIndex: function () {
                 return loopIndex++;
@@ -683,7 +682,7 @@ module.exports = {
         },
         'N_ARRAY_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToArray'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToArray'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -725,7 +724,7 @@ module.exports = {
                     elementValueChunks.push(', ');
                 }
 
-                elementValueChunks.push(interpret(element, {getValue: true}));
+                elementValueChunks.push(interpret(element));
             });
 
             return context.createExpressionSourceNode(
@@ -738,7 +737,7 @@ module.exports = {
         },
         'N_BINARY_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToString'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToString'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -756,7 +755,7 @@ module.exports = {
         },
         'N_BOOLEAN_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToBoolean'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToBoolean'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -834,7 +833,7 @@ module.exports = {
                             'getClassConstant'
                     ),
                     '(',
-                    interpret(node.className, {getValue: true, allowBareword: true}),
+                    interpret(node.className, {allowBareword: true}),
                     ', ',
                     JSON.stringify(node.constant),
                     ')'
@@ -908,7 +907,7 @@ module.exports = {
         },
         'N_CLONE_EXPRESSION': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('clone'), '(', interpret(node.operand, {getValue: true}), ')'],
+                [context.useCoreSymbol('clone'), '(', interpret(node.operand), ')'],
                 node
             );
         },
@@ -1124,7 +1123,7 @@ module.exports = {
         },
         'N_DOUBLE_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToFloat'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToFloat'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -1147,7 +1146,7 @@ module.exports = {
                 [
                     context.useCoreSymbol('isEmpty'),
                     '()(',
-                    interpret(node.variable, {getValue: false}),
+                    interpret(node.variable),
                     ')'
                 ],
                 node
@@ -1158,7 +1157,7 @@ module.exports = {
                 [
                     context.useCoreSymbol('eval'),
                     '(',
-                    interpret(node.code, {getValue: true}),
+                    interpret(node.code),
                     ')'
                 ],
                 node
@@ -1193,7 +1192,7 @@ module.exports = {
             var chunks = [],
                 isAssignment = /^(?:[-+*/.%&|^]|<<|>>)?=$/.test(node.right[0].operator),
                 isReference,
-                leftChunks = interpret(node.left, {assignment: isAssignment, getValue: !isAssignment}),
+                leftChunks = interpret(node.left, {assignment: isAssignment}),
                 operation,
                 method,
                 rightOperand,
@@ -1335,7 +1334,7 @@ module.exports = {
             var arrayValue = interpret(node.array),
                 iteratorVariable,
                 codeChunks = [],
-                key = node.key ? interpret(node.key, {getValue: false}) : null,
+                key = node.key ? interpret(node.key) : null,
                 blockContexts = context.blockContexts.concat(['foreach']),
                 labelRepository = context.labelRepository,
                 labelsInsideLoopHash = {},
@@ -1347,7 +1346,7 @@ module.exports = {
                 },
                 valueIsReference = node.value.name === 'N_REFERENCE',
                 nodeValue = valueIsReference ? node.value.operand : node.value,
-                value = interpret(nodeValue, {getValue: false}),
+                value = interpret(nodeValue),
                 loopIndex = context.nextLoopIndex();
 
             iteratorVariable = 'iterator_' + blockContexts.length;
@@ -1484,7 +1483,7 @@ module.exports = {
                     argChunks.push(', ');
                 }
 
-                argChunks.push(interpret(arg, {getValue: false}));
+                argChunks.push(interpret(arg));
             });
 
             if (node.func.name === 'N_STRING') {
@@ -1507,7 +1506,7 @@ module.exports = {
                 callChunks = [
                     context.useCoreSymbol('callVariableFunction'),
                     '(',
-                    interpret(node.func, {getValue: true, allowBareword: true}),
+                    interpret(node.func, {allowBareword: true}),
 
                     // Only append arguments array if non-empty
                     argChunks.length > 0 ?
@@ -1576,7 +1575,7 @@ module.exports = {
             // Alternate statements are executed if the condition is falsy
             var alternateCodeChunks,
                 codeChunks,
-                conditionCodeChunks = [context.useCoreSymbol('if_'), '(', interpret(node.condition, {getValue: true}), ')'],
+                conditionCodeChunks = [context.useCoreSymbol('if_'), '(', interpret(node.condition), ')'],
                 consequentCodeChunks,
                 gotosJumpingIn = {},
                 labelRepository = context.labelRepository;
@@ -1628,7 +1627,7 @@ module.exports = {
                 [
                     context.useCoreSymbol('instanceOf'),
                     '(',
-                    interpret(node.object, {getValue: true}),
+                    interpret(node.object),
                     ', ',
                     interpret(node['class'], {allowBareword: true}),
                     ')'
@@ -1660,7 +1659,7 @@ module.exports = {
         },
         'N_INTEGER_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToInteger'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToInteger'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -1746,7 +1745,7 @@ module.exports = {
                     issetChunks.push(', ');
                 }
 
-                issetChunks.push(interpret(variable, {getValue: false}));
+                issetChunks.push(interpret(variable));
             });
 
             return context.createExpressionSourceNode(
@@ -1806,7 +1805,7 @@ module.exports = {
                     elementsCodeChunks.push(', ');
                 }
 
-                elementsCodeChunks.push(interpret(element, {getValue: false}));
+                elementsCodeChunks.push(interpret(element));
             });
 
             return context.createExpressionSourceNode(
@@ -1869,14 +1868,14 @@ module.exports = {
                     argChunks.push(', ');
                 }
 
-                argChunks.push(interpret(argNode, {getValue: false}));
+                argChunks.push(interpret(argNode));
             });
 
             return context.createExpressionSourceNode(
                 [
                     context.useCoreSymbol(isVariable ? 'callVariableInstanceMethod' : 'callInstanceMethod'),
                     '(',
-                    interpret(node.object, {getValue: true}),
+                    interpret(node.object),
                     ', ',
                     isVariable ? interpret(node.method, {allowBareword: true}) : JSON.stringify(node.method.string),
                     argChunks.length > 0 ? [', ['].concat(argChunks, ']') : [],
@@ -1954,7 +1953,7 @@ module.exports = {
                 [
                     context.useCoreSymbol('createInstance'),
                     '(',
-                    interpret(node.className, {allowBareword: true, getValue: true}),
+                    interpret(node.className, {allowBareword: true}),
                     ', [',
                     argChunks,
                     '])'
@@ -1976,9 +1975,9 @@ module.exports = {
                 [
                     context.useCoreSymbol('nullCoalesce'),
                     '()(',
-                    interpret(node.left, {getValue: false}),
+                    interpret(node.left),
                     ', ',
-                    interpret(node.right, {getValue: false}),
+                    interpret(node.right),
                     ')'
                 ],
                 node
@@ -1986,7 +1985,7 @@ module.exports = {
         },
         'N_OBJECT_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToObject'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToObject'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -1997,10 +1996,10 @@ module.exports = {
 
             if (context.assignment) {
                 objectVariableCodeChunks = [
-                    interpret(node.object, {getValue: false})
+                    interpret(node.object)
                 ];
             } else {
-                objectVariableCodeChunks = interpret(node.object, {getValue: true});
+                objectVariableCodeChunks = interpret(node.object);
             }
 
             property = node.property;
@@ -2020,7 +2019,7 @@ module.exports = {
                     '(',
                     objectVariableCodeChunks,
                     ', ',
-                    interpret(property, {assignment: false, getValue: true, allowBareword: true}),
+                    interpret(property, {assignment: false, allowBareword: true}),
                     ')'
                 );
             }
@@ -2046,7 +2045,7 @@ module.exports = {
                 [
                     context.useCoreSymbol('print'),
                     '(',
-                    interpret(node.operand, {getValue: true}),
+                    interpret(node.operand),
                     ')'
                     // Note that core.print(...) will return int(1) as the result of the expression
                 ],
@@ -2360,7 +2359,7 @@ module.exports = {
                 [
                     context.useCoreSymbol('getReference'),
                     '(',
-                    interpret(node.operand, {getValue: false}),
+                    interpret(node.operand),
                     ')'
                 ],
                 node
@@ -2414,7 +2413,7 @@ module.exports = {
                     argChunks.push(', ');
                 }
 
-                argChunks.push(interpret(arg, {getValue: false}));
+                argChunks.push(interpret(arg));
             });
 
             return context.createExpressionSourceNode(
@@ -2462,7 +2461,7 @@ module.exports = {
             };
         },
         'N_STATIC_PROPERTY': function (node, interpret, context) {
-            var classVariableCodeChunks = interpret(node.className, {getValue: true, allowBareword: true}),
+            var classVariableCodeChunks = interpret(node.className, {allowBareword: true}),
                 propertyCodeChunks = [];
 
             if (node.property.name === 'N_STRING') {
@@ -2480,7 +2479,7 @@ module.exports = {
                     '(',
                     classVariableCodeChunks,
                     ', ',
-                    interpret(node.property, {assignment: false, getValue: true, allowBareword: true}),
+                    interpret(node.property, {assignment: false, allowBareword: true}),
                     ')'
                 );
             }
@@ -2545,7 +2544,7 @@ module.exports = {
         },
         'N_STRING_CAST': function (node, interpret, context) {
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('coerceToString'), '(', interpret(node.value, {getValue: true}), ')'],
+                [context.useCoreSymbol('coerceToString'), '(', interpret(node.value), ')'],
                 node
             );
         },
@@ -2692,7 +2691,7 @@ module.exports = {
             return context.createStatementSourceNode(codeChunks, node);
         },
         'N_TERNARY': function (node, interpret, context) {
-            var condition = interpret(node.condition, {getValue: true}),
+            var condition = interpret(node.condition),
                 consequent,
                 expression;
 
@@ -2736,7 +2735,7 @@ module.exports = {
                     JSON.stringify(catchNode.type.string), ', e)) {',
                     context.useCoreSymbol('setValue'),
                     '(',
-                    interpret(catchNode.variable, {getValue: false}),
+                    interpret(catchNode.variable),
                     ', e);',
                     interpret(catchNode.body),
                     '}'
@@ -2772,7 +2771,7 @@ module.exports = {
         },
         'N_UNARY_EXPRESSION': function (node, interpret, context) {
             var operator = node.operator,
-                operand = interpret(node.operand, {getValue: operator !== '++' && operator !== '--'});
+                operand = interpret(node.operand);
 
             return context.createExpressionSourceNode(
                 [
@@ -2787,7 +2786,7 @@ module.exports = {
         'N_UNSET_CAST': function (node, interpret, context) {
             // Unset cast coerces all values to NULL
             return context.createExpressionSourceNode(
-                ['(', interpret(node.value, {getValue: true}), ', ', context.useCoreSymbol('nullValue'), ')'],
+                ['(', interpret(node.value), ', ', context.useCoreSymbol('nullValue'), ')'],
                 node
             );
         },
@@ -2799,7 +2798,7 @@ module.exports = {
                     statementChunks.push(', ');
                 }
 
-                statementChunks.push(interpret(variableNode, {getValue: false}));
+                statementChunks.push(interpret(variableNode));
             });
 
             return context.createStatementSourceNode(

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -133,7 +133,7 @@ function hoistDeclarations(statements) {
         nonDeclarations = [];
 
     _.each(statements, function (statement) {
-        if (/^N_(CLASS|FUNCTION|USE)_STATEMENT$/.test(statement.name)) {
+        if (/^N_(CLASS|FUNCTION|INTERFACE|USE)_STATEMENT$/.test(statement.name)) {
             declarations.push(statement);
         } else {
             nonDeclarations.push(statement);

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -1410,7 +1410,7 @@ module.exports = {
             });
 
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('interpolate'), '(', codeChunks, ')'],
+                [context.useCoreSymbol('interpolate'), '([', codeChunks, '])'],
                 node
             );
         },
@@ -1595,9 +1595,9 @@ module.exports = {
             return context.createExpressionSourceNode(
                 [
                     context.useCoreSymbol('isSet'),
-                    '()(',
+                    '()([',
                     issetChunks,
-                    ')'
+                    '])'
                 ],
                 node
             );
@@ -2410,7 +2410,7 @@ module.exports = {
             });
 
             return context.createExpressionSourceNode(
-                [context.useCoreSymbol('interpolate'), '(', codeChunks, ')'],
+                [context.useCoreSymbol('interpolate'), '([', codeChunks, '])'],
                 node
             );
         },
@@ -2601,7 +2601,9 @@ module.exports = {
             });
 
             return context.createStatementSourceNode(
-                [context.useCoreSymbol('unset'), '(', statementChunks, ');'],
+                // TODO: Have a separate opcode that takes a list to remove need for array
+                //       when there is only a single item to unset, to shrink bundle and reduce GC pressure
+                [context.useCoreSymbol('unset'), '([', statementChunks, ']);'],
                 node
             );
         },

--- a/src/transpilerSpec.js
+++ b/src/transpilerSpec.js
@@ -763,11 +763,10 @@ module.exports = {
 
             return context.createStatementSourceNode(
                 [
-                    '(function () {var currentClass = ',
                     context.useCoreSymbol('defineClass'),
                     '(' + JSON.stringify(node.className) + ', ',
                     codeChunks,
-                    ');}());'
+                    ');'
                 ],
                 node
             );
@@ -832,7 +831,11 @@ module.exports = {
                 return {
                     name: constant.constant,
                     value: context.createInternalSourceNode(
-                        ['function () { return '].concat(interpret(constant.value, {isConstantOrProperty: true}), '; }'),
+                        [
+                            'function (currentClass) { return ',
+                            interpret(constant.value, {isConstantOrProperty: true}),
+                            '; }'
+                        ],
                         constant
                     )
                 };
@@ -1483,7 +1486,11 @@ module.exports = {
                 value: context.createInternalSourceNode(
                     // Output a function that can be called to create the property's value,
                     // so that each instance gets a separate array object (if one is used as the value)
-                    ['function () { return '].concat(node.value ? interpret(node.value, {isConstantOrProperty: true}) : ['null'], '; }'),
+                    [
+                        'function (currentClass) { return ',
+                        node.value ? interpret(node.value, {isConstantOrProperty: true}) : ['null'],
+                        '; }'
+                    ],
                     node
                 )
             };
@@ -1560,11 +1567,10 @@ module.exports = {
 
             return context.createStatementSourceNode(
                 [
-                    '(function () {var currentClass = ',
                     context.useCoreSymbol('defineInterface'),
                     '(' + JSON.stringify(node.interfaceName) + ', ',
                     codeChunks,
-                    ');}());'
+                    ');'
                 ],
                 node
             );

--- a/test/integration/transpiler/constructs/emptyTest.js
+++ b/test/integration/transpiler/constructs/emptyTest.js
@@ -29,12 +29,9 @@ describe('Transpiler empty(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();' +
-            'var result = tools.valueFactory.createBoolean(scope.getVariable("a_var").isEmpty());' +
-            'scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, isEmpty = core.isEmpty;' +
+            'return isEmpty()(getVariable("a_var"));' +
             '});'
         );
     });
@@ -52,29 +49,24 @@ describe('Transpiler empty(...) construct expression test', function () {
                             name: 'N_VARIABLE',
                             variable: 'myArray'
                         },
-                        indices: [{
-                            index: {
-                                name: 'N_INTEGER',
-                                number: 21
-                            }
-                        }]
+                        index: {
+                            name: 'N_INTEGER',
+                            number: 21
+                        }
                     }
                 }
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();var result = tools.valueFactory.createBoolean(' +
-            'scope.getVariable("myArray").getValue().getElementByKey(tools.valueFactory.createInteger(21)).isEmpty()' +
-            ');scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getElement = core.getElement, getVariable = core.getVariable, isEmpty = core.isEmpty;' +
+            'return isEmpty()(getElement(getVariable("myArray"), 21));' +
             '});'
         );
     });
 
-    it('should correctly transpile a return statement with array element access', function () {
+    it('should correctly transpile a return statement with instance property access', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -82,29 +74,24 @@ describe('Transpiler empty(...) construct expression test', function () {
                 expression: {
                     name: 'N_EMPTY',
                     variable: {
-                        name: 'N_ARRAY_INDEX',
-                        array: {
+                        name: 'N_OBJECT_PROPERTY',
+                        object: {
                             name: 'N_VARIABLE',
-                            variable: 'myArray'
+                            variable: 'myObject'
                         },
-                        indices: [{
-                            index: {
-                                name: 'N_INTEGER',
-                                number: 21
-                            }
-                        }]
+                        property: {
+                            name: 'N_STRING',
+                            string: 'myProp'
+                        }
                     }
                 }
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();var result = tools.valueFactory.createBoolean(' +
-            'scope.getVariable("myArray").getValue().getElementByKey(tools.valueFactory.createInteger(21)).isEmpty()' +
-            ');scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getInstanceProperty = core.getInstanceProperty, getVariable = core.getVariable, isEmpty = core.isEmpty;' +
+            'return isEmpty()(getInstanceProperty(getVariable("myObject"), "myProp"));' +
             '});'
         );
     });
@@ -131,12 +118,9 @@ describe('Transpiler empty(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();var result = tools.valueFactory.createBoolean(' +
-            'scope.getClassNameOrThrow().getStaticPropertyByName(tools.valueFactory.createBarewordString("myProp"), namespaceScope).isEmpty()' +
-            ');scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getClassNameOrThrow = core.getClassNameOrThrow, getStaticProperty = core.getStaticProperty, isEmpty = core.isEmpty;' +
+            'return isEmpty()(getStaticProperty(getClassNameOrThrow(), "myProp"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/evalTest.js
+++ b/test/integration/transpiler/constructs/evalTest.js
@@ -29,10 +29,9 @@ describe('Transpiler eval(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.eval(scope.getVariable("myCode").getValue().getNative(), scope);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var eval = core.eval, getVariable = core.getVariable;' +
+            'return eval(getVariable("myCode"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/exitTest.js
+++ b/test/integration/transpiler/constructs/exitTest.js
@@ -25,10 +25,9 @@ describe('Transpiler exit(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'tools.exit();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var exit = core.exit;' +
+            'exit();' +
             '});'
         );
     });
@@ -49,10 +48,9 @@ describe('Transpiler exit(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'tools.exit(tools.valueFactory.createInteger(21));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, exit = core.exit;' +
+            'exit(createInteger(21));' +
             '});'
         );
     });
@@ -73,10 +71,9 @@ describe('Transpiler exit(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '(stdout.write(tools.valueFactory.createString("My failure message").getNative()), tools.exit());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, exit = core.exit, print = core.print;' +
+            '(print(createString("My failure message")), exit());' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/heredocTest.js
+++ b/test/integration/transpiler/constructs/heredocTest.js
@@ -38,15 +38,14 @@ describe('Transpiler "heredoc" statement test', function () {
             };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString(' +
-            'tools.valueFactory.createString("Increase ").coerceToString().getNative() + ' +
-            'scope.getVariable("firstVar").getValue().coerceToString().getNative() + ' +
-            'tools.valueFactory.createString(" with ").coerceToString().getNative() + ' +
-            'scope.getVariable("secondVar").getValue().coerceToString().getNative()' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, interpolate = core.interpolate;' +
+            'return interpolate(' +
+            '"Increase ", ' +
+            'getVariable("firstVar"), ' +
+            '" with ", ' +
+            'getVariable("secondVar")' +
             ');' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/heredocTest.js
+++ b/test/integration/transpiler/constructs/heredocTest.js
@@ -40,12 +40,12 @@ describe('Transpiler "heredoc" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getVariable = core.getVariable, interpolate = core.interpolate;' +
-            'return interpolate(' +
+            'return interpolate([' +
             '"Increase ", ' +
             'getVariable("firstVar"), ' +
             '" with ", ' +
             'getVariable("secondVar")' +
-            ');' +
+            ']);' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/issetTest.js
+++ b/test/integration/transpiler/constructs/issetTest.js
@@ -29,12 +29,9 @@ describe('Transpiler isset(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();' +
-            'var result = tools.valueFactory.createBoolean(scope.getVariable("a_var").isSet());' +
-            'scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, isSet = core.isSet;' +
+            'return isSet()(getVariable("a_var"));' +
             '});'
         );
     });
@@ -58,12 +55,9 @@ describe('Transpiler isset(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();' +
-            'var result = tools.valueFactory.createBoolean(scope.getVariable("a_var").isSet() && scope.getVariable("another_var").isSet());' +
-            'scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, isSet = core.isSet;' +
+            'return isSet()(getVariable("a_var"), getVariable("another_var"));' +
             '});'
         );
     });
@@ -81,24 +75,19 @@ describe('Transpiler isset(...) construct expression test', function () {
                             name: 'N_VARIABLE',
                             variable: 'myArray'
                         },
-                        indices: [{
-                            index: {
-                                name: 'N_INTEGER',
-                                number: 21
-                            }
-                        }]
+                        index: {
+                            name: 'N_INTEGER',
+                            number: 21
+                        }
                     }]
                 }
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressOwnErrors();var result = tools.valueFactory.createBoolean(' +
-            'scope.getVariable("myArray").getValue().getElementByKey(tools.valueFactory.createInteger(21)).isSet()' +
-            ');scope.unsuppressOwnErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getElement = core.getElement, getVariable = core.getVariable, isSet = core.isSet;' +
+            'return isSet()(getElement(getVariable("myArray"), 21));' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/issetTest.js
+++ b/test/integration/transpiler/constructs/issetTest.js
@@ -31,7 +31,7 @@ describe('Transpiler isset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getVariable = core.getVariable, isSet = core.isSet;' +
-            'return isSet()(getVariable("a_var"));' +
+            'return isSet()([getVariable("a_var")]);' +
             '});'
         );
     });
@@ -57,7 +57,7 @@ describe('Transpiler isset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getVariable = core.getVariable, isSet = core.isSet;' +
-            'return isSet()(getVariable("a_var"), getVariable("another_var"));' +
+            'return isSet()([getVariable("a_var"), getVariable("another_var")]);' +
             '});'
         );
     });
@@ -87,7 +87,7 @@ describe('Transpiler isset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getElement = core.getElement, getVariable = core.getVariable, isSet = core.isSet;' +
-            'return isSet()(getElement(getVariable("myArray"), 21));' +
+            'return isSet()([getElement(getVariable("myArray"), 21)]);' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/listTest.js
+++ b/test/integration/transpiler/constructs/listTest.js
@@ -1,0 +1,92 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler list(...) construct test', function () {
+    it('should correctly transpile a simple assignment to list with one variable of array with one element', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_LIST',
+                        elements: [{
+                            name: 'N_VARIABLE',
+                            variable: 'myVar'
+                        }]
+                    },
+                    right: [{
+                        operator: '=',
+                        operand: {
+                            name: 'N_ARRAY_LITERAL',
+                            elements: [{
+                                name: 'N_INTEGER',
+                                number: '21'
+                            }]
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createArray = core.createArray, createInteger = core.createInteger, createList = core.createList, getVariable = core.getVariable, setValue = core.setValue;' +
+            'setValue(createList([getVariable("myVar")]), createArray([createInteger(21)]));' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile an assignment to list with one variable (after skipping first value) of array with two elements', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_LIST',
+                        elements: [{
+                            name: 'N_VOID'
+                        }, {
+                            name: 'N_VARIABLE',
+                            variable: 'myVar'
+                        }]
+                    },
+                    right: [{
+                        operator: '=',
+                        operand: {
+                            name: 'N_ARRAY_LITERAL',
+                            elements: [{
+                                name: 'N_INTEGER',
+                                number: '4'
+                            }, {
+                                name: 'N_INTEGER',
+                                number: '21'
+                            }]
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createArray = core.createArray, createInteger = core.createInteger, createList = core.createList, createVoid = core.createVoid, getVariable = core.getVariable, setValue = core.setValue;' +
+            'setValue(createList([createVoid(), getVariable("myVar")]), createArray([createInteger(4), createInteger(21)]));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/constructs/nowdocTest.js
+++ b/test/integration/transpiler/constructs/nowdocTest.js
@@ -26,12 +26,11 @@ describe('Transpiler "nowdoc" statement test', function () {
             };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString(' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString(' +
             '"my nowdoc with strings that $look like $interpolated variables"' +
             ');' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/parentKeywordTest.js
+++ b/test/integration/transpiler/constructs/parentKeywordTest.js
@@ -32,10 +32,9 @@ describe('Transpiler parent:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getParentClassNameOrThrow().getStaticPropertyByName(tools.valueFactory.createBarewordString("myProp"), namespaceScope).getValue();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getStaticProperty = core.getStaticProperty, getSuperClassNameOrThrow = core.getSuperClassNameOrThrow;' +
+            'return getStaticProperty(getSuperClassNameOrThrow(), "myProp");' +
             '});'
         );
     });
@@ -63,10 +62,10 @@ describe('Transpiler parent:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass, getClassConstant = core.getClassConstant, getSuperClassName = core.getSuperClassName;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
@@ -74,13 +73,11 @@ describe('Transpiler parent:: construct expression test', function () {
             'methods: {}, ' +
             'constants: {' +
             '"MY_CONST": function () { ' +
-            'return tools.getParentClassName(currentClass)' +
-            '.getConstantByName("PARENT_CONST", namespaceScope); ' +
+            'return getClassConstant(getSuperClassName(currentClass), "PARENT_CONST"); ' +
             '}' +
             '}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -107,11 +104,9 @@ describe('Transpiler parent:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getParentClassNameOrThrow()' +
-            '.callStaticMethod(tools.valueFactory.createBarewordString("myMethod"), [], namespaceScope, true);' + // Forwarding
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callStaticMethod = core.callStaticMethod, getSuperClassNameOrThrow = core.getSuperClassNameOrThrow;' +
+            'callStaticMethod(getSuperClassNameOrThrow(), "myMethod", [], true);' + // Forwarding
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/parentKeywordTest.js
+++ b/test/integration/transpiler/constructs/parentKeywordTest.js
@@ -64,20 +64,18 @@ describe('Transpiler parent:: construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var defineClass = core.defineClass, getClassConstant = core.getClassConstant, getSuperClassName = core.getSuperClassName;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {' +
-            '"MY_CONST": function () { ' +
+            '"MY_CONST": function (currentClass) { ' +
             'return getClassConstant(getSuperClassName(currentClass), "PARENT_CONST"); ' +
             '}' +
             '}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/selfKeywordTest.js
+++ b/test/integration/transpiler/constructs/selfKeywordTest.js
@@ -32,10 +32,9 @@ describe('Transpiler self:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getClassNameOrThrow().getStaticPropertyByName(tools.valueFactory.createBarewordString("myProp"), namespaceScope).getValue();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getClassNameOrThrow = core.getClassNameOrThrow, getStaticProperty = core.getStaticProperty;' +
+            'return getStaticProperty(getClassNameOrThrow(), "myProp");' +
             '});'
         );
     });
@@ -62,11 +61,9 @@ describe('Transpiler self:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getClassNameOrThrow()' +
-            '.callStaticMethod(tools.valueFactory.createBarewordString("myMethod"), [], namespaceScope, true);' + // Forwarding
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callStaticMethod = core.callStaticMethod, getClassNameOrThrow = core.getClassNameOrThrow;' +
+            'callStaticMethod(getClassNameOrThrow(), "myMethod", [], true);' + // Forwarding
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/staticKeywordTest.js
+++ b/test/integration/transpiler/constructs/staticKeywordTest.js
@@ -32,17 +32,16 @@ describe('Transpiler static:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getStaticClassNameOrThrow().getStaticPropertyByName(tools.valueFactory.createBarewordString("myProp"), namespaceScope).getValue();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getStaticClassName = core.getStaticClassName, getStaticProperty = core.getStaticProperty;' +
+            'return getStaticProperty(getStaticClassName(), "myProp");' +
             '});'
         );
     });
 
     // Calls to static methods with keywords eg. self::, parent:: and static:: are always forwarding,
     // calls to the same methods with the class name eg. MyClass:: are non-forwarding
-    it('should correctly transpile a call to a method with parent:: (forwarding)', function () {
+    it('should correctly transpile a call to a method with static:: (forwarding)', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -62,11 +61,9 @@ describe('Transpiler static:: construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getStaticClassNameOrThrow()' +
-            '.callStaticMethod(tools.valueFactory.createBarewordString("myMethod"), [], namespaceScope, true);' + // Forwarding
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callStaticMethod = core.callStaticMethod, getStaticClassName = core.getStaticClassName;' +
+            'callStaticMethod(getStaticClassName(), "myMethod", [], true);' + // Forwarding
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/stringInterpolationTest.js
+++ b/test/integration/transpiler/constructs/stringInterpolationTest.js
@@ -38,7 +38,7 @@ describe('Transpiler string interpolation construct test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getVariable = core.getVariable, interpolate = core.interpolate;' +
-            'return interpolate("The num\\"ber is $", getVariable("myVar"), ".");' +
+            'return interpolate(["The num\\"ber is $", getVariable("myVar"), "."]);' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/stringInterpolationTest.js
+++ b/test/integration/transpiler/constructs/stringInterpolationTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler string interpolation construct test', function () {
+    it('should correctly transpile a return of string with interpolated variable', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STRING_EXPRESSION',
+                    parts: [{
+                        name: 'N_STRING_LITERAL',
+                        // Embed a quote to check for escaping
+                        string: 'The num\"ber is $'
+                    }, {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    }, {
+                        name: 'N_STRING_LITERAL',
+                        string: '.'
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, interpolate = core.interpolate;' +
+            'return interpolate("The num\\"ber is $", getVariable("myVar"), ".");' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/constructs/unsetTest.js
+++ b/test/integration/transpiler/constructs/unsetTest.js
@@ -26,10 +26,9 @@ describe('Transpiler unset(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("a_var").unset();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, unset = core.unset;' +
+            'unset(getVariable("a_var"));' +
             '});'
         );
     });
@@ -50,10 +49,9 @@ describe('Transpiler unset(...) construct expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("first_var").unset(); scope.getVariable("second_var").unset();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, unset = core.unset;' +
+            'unset(getVariable("first_var"), getVariable("second_var"));' +
             '});'
         );
     });
@@ -69,21 +67,18 @@ describe('Transpiler unset(...) construct expression test', function () {
                         name: 'N_VARIABLE',
                         variable: 'myArray'
                     },
-                    indices: [{
-                        index: {
-                            name: 'N_INTEGER',
-                            number: 21
-                        }
-                    }]
+                    index: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    }
                 }]
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myArray").getValue().getElementByKey(tools.valueFactory.createInteger(21)).unset();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getElement = core.getElement, getVariable = core.getVariable, unset = core.unset;' +
+            'unset(getElement(getVariable("myArray"), 21));' +
             '});'
         );
     });
@@ -99,21 +94,18 @@ describe('Transpiler unset(...) construct expression test', function () {
                         name: 'N_VARIABLE',
                         variable: 'an_object'
                     },
-                    properties: [{
-                        property: {
-                            name: 'N_STRING',
-                            string: 'prop'
-                        }
-                    }]
+                    property: {
+                        name: 'N_STRING',
+                        string: 'prop'
+                    }
                 }]
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("an_object").getValue().getInstancePropertyByName(tools.valueFactory.createBarewordString("prop")).unset();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getInstanceProperty = core.getInstanceProperty, getVariable = core.getVariable, unset = core.unset;' +
+            'unset(getInstanceProperty(getVariable("an_object"), "prop"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/unsetTest.js
+++ b/test/integration/transpiler/constructs/unsetTest.js
@@ -28,7 +28,7 @@ describe('Transpiler unset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getVariable = core.getVariable, unset = core.unset;' +
-            'unset(getVariable("a_var"));' +
+            'unset([getVariable("a_var")]);' +
             '});'
         );
     });
@@ -51,7 +51,7 @@ describe('Transpiler unset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getVariable = core.getVariable, unset = core.unset;' +
-            'unset(getVariable("first_var"), getVariable("second_var"));' +
+            'unset([getVariable("first_var"), getVariable("second_var")]);' +
             '});'
         );
     });
@@ -78,7 +78,7 @@ describe('Transpiler unset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getElement = core.getElement, getVariable = core.getVariable, unset = core.unset;' +
-            'unset(getElement(getVariable("myArray"), 21));' +
+            'unset([getElement(getVariable("myArray"), 21)]);' +
             '});'
         );
     });
@@ -105,7 +105,7 @@ describe('Transpiler unset(...) construct expression test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var getInstanceProperty = core.getInstanceProperty, getVariable = core.getVariable, unset = core.unset;' +
-            'unset(getInstanceProperty(getVariable("an_object"), "prop"));' +
+            'unset([getInstanceProperty(getVariable("an_object"), "prop")]);' +
             '});'
         );
     });

--- a/test/integration/transpiler/constructs/variable/variableVariableTest.js
+++ b/test/integration/transpiler/constructs/variable/variableVariableTest.js
@@ -1,0 +1,38 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler variable-variable construct test', function () {
+    it('should correctly transpile a return of variable-variable', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_VARIABLE_EXPRESSION',
+                    expression: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVariableNameVar'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, getVariableVariable = core.getVariableVariable;' +
+            'return getVariableVariable(getVariable("myVariableNameVar"));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/expressions/arrayLiteralTest.js
+++ b/test/integration/transpiler/expressions/arrayLiteralTest.js
@@ -13,7 +13,7 @@ var expect = require('chai').expect,
     phpToJS = require('../../../..');
 
 describe('Transpiler array literal expression test', function () {
-    it('should correctly transpile a return of array with immediate integer and variable reference', function () {
+    it('should correctly transpile a return of array with immediate integer, variable and variable reference', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -38,19 +38,18 @@ describe('Transpiler array literal expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createArray([' +
-            'tools.valueFactory.createInteger(21), ' +
-            'scope.getVariable("myVarByVal").getValue(), ' +
-            'scope.getVariable("myVarByRef").getReference()' +
+            'function (core) {' +
+            'var createArray = core.createArray, createInteger = core.createInteger, getReference = core.getReference, getVariable = core.getVariable;' +
+            'return createArray([' +
+            'createInteger(21), ' +
+            'getVariable("myVarByVal"), ' +
+            'getReference(getVariable("myVarByRef"))' +
             ']);' +
-            'return tools.valueFactory.createNull();' +
             '}'
         );
     });
 
-    it('should correctly transpile an assignment array with immediate integer, variable, array element and object property references', function () {
+    it('should correctly transpile an assignment of array with immediate integer, variable, array element and object property references', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -85,12 +84,10 @@ describe('Transpiler array literal expression test', function () {
                                         name: 'N_VARIABLE',
                                         variable: 'myArray'
                                     },
-                                    indices: [{
-                                        index: {
-                                            name: 'N_STRING_LITERAL',
-                                            string: 'myElementByRef'
-                                        }
-                                    }]
+                                    index: {
+                                        name: 'N_STRING_LITERAL',
+                                        string: 'myElementByRef'
+                                    }
                                 }
                             }, {
                                 name: 'N_REFERENCE',
@@ -100,12 +97,10 @@ describe('Transpiler array literal expression test', function () {
                                         name: 'N_VARIABLE',
                                         variable: 'myObject'
                                     },
-                                    properties: [{
-                                        property: {
-                                            name: 'N_STRING',
-                                            string: 'myElementByRef'
-                                        }
-                                    }]
+                                    property: {
+                                        name: 'N_STRING',
+                                        string: 'myPropertyByRef'
+                                    }
                                 }
                             }]
                         }
@@ -115,16 +110,15 @@ describe('Transpiler array literal expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myTarget").setValue(tools.valueFactory.createArray([' +
-            'tools.valueFactory.createInteger(21), ' +
-            'scope.getVariable("myVarByVal").getValue(), ' +
-            'scope.getVariable("myVarByRef").getReference(), ' +
-            'scope.getVariable("myArray").getValue().getElementByKey(tools.valueFactory.createString("myElementByRef")).getReference(), ' +
-            'scope.getVariable("myObject").getValue().getInstancePropertyByName(tools.valueFactory.createBarewordString("myElementByRef")).getReference()' +
+            'function (core) {' +
+            'var createArray = core.createArray, createInteger = core.createInteger, getElement = core.getElement, getInstanceProperty = core.getInstanceProperty, getReference = core.getReference, getVariable = core.getVariable, setValue = core.setValue;' +
+            'setValue(getVariable("myTarget"), createArray([' +
+            'createInteger(21), ' +
+            'getVariable("myVarByVal"), ' +
+            'getReference(getVariable("myVarByRef")), ' +
+            'getReference(getElement(getVariable("myArray"), "myElementByRef")), ' +
+            'getReference(getInstanceProperty(getVariable("myObject"), "myPropertyByRef"))' +
             ']));' +
-            'return tools.valueFactory.createNull();' +
             '}'
         );
     });
@@ -165,13 +159,12 @@ describe('Transpiler array literal expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createArray([' +
-            'tools.createKeyValuePair(tools.valueFactory.createString("myKeyForVal"), scope.getVariable("myVarByVal").getValue()), ' +
-            'tools.createKeyReferencePair(tools.valueFactory.createString("myKeyForRef"), scope.getVariable("myVarByRef").getReference())' +
+            'function (core) {' +
+            'var createArray = core.createArray, createKeyReferencePair = core.createKeyReferencePair, createKeyValuePair = core.createKeyValuePair, createString = core.createString, getVariable = core.getVariable;' +
+            'return createArray([' +
+            'createKeyValuePair(createString("myKeyForVal"), getVariable("myVarByVal")), ' +
+            'createKeyReferencePair(createString("myKeyForRef"), getVariable("myVarByRef"))' +
             ']);' +
-            'return tools.valueFactory.createNull();' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/binaryStringTest.js
+++ b/test/integration/transpiler/expressions/binaryStringTest.js
@@ -26,10 +26,9 @@ describe('Transpiler binary string expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("My binary string");' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("My binary string");' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/booleanTest.js
+++ b/test/integration/transpiler/expressions/booleanTest.js
@@ -1,0 +1,55 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler boolean expression test', function () {
+    it('should correctly transpile a return of boolean true', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_BOOLEAN',
+                    bool: true
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var trueValue = core.trueValue;' +
+            'return trueValue;' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a return of boolean false', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_BOOLEAN',
+                    bool: false
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var falseValue = core.falseValue;' +
+            'return falseValue;' +
+            '}'
+        );
+    });
+});

--- a/test/integration/transpiler/expressions/closureTest.js
+++ b/test/integration/transpiler/expressions/closureTest.js
@@ -74,26 +74,24 @@ describe('Transpiler closure expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.createClosure(' +
+            'function (core) {' +
+            'var createClosure = core.createClosure, createInteger = core.createInteger, echo = core.echo, getVariable = core.getVariable, getVariableForScope = core.getVariableForScope, scope = core.scope, setReference = core.setReference, setValue = core.setValue;' +
+            'return createClosure(' +
             '(function (parentScope) { ' +
             'return function ($arg1, $arg2, $arg3) {' +
-            'var scope = this;' +
-            'scope.getVariable("arg1").setValue($arg1.getValue());' +
-            'scope.getVariable("arg2").setReference($arg2.getReference());' +
-            'scope.getVariable("arg3").setValue($arg3.getValue());' +
-            'scope.getVariable("bound1").setValue(parentScope.getVariable("bound1").getValue());' +
-            'scope.getVariable("bound2").setReference(parentScope.getVariable("bound2").getReference());' +
-            'stdout.write(tools.valueFactory.createInteger(21).coerceToString().getNative());' +
+            'setValue(getVariable("arg1"), $arg1);' +
+            'setReference(getVariable("arg2"), $arg2);' +
+            'setValue(getVariable("arg3"), $arg3);' +
+            'setValue(getVariable("bound1"), getVariableForScope("bound1", parentScope));' +
+            'setReference(getVariable("bound2"), getVariableForScope("bound2", parentScope));' +
+            'echo(createInteger(21));' +
             '}; ' +
             '}(scope)), ' +
-            'scope, namespaceScope, [' +
+            '[' +
             '{"name":"arg1"},' +
             '{"type":"array","name":"arg2","ref":true},' +
-            '{"name":"arg3","value":function () { return tools.valueFactory.createInteger(21); }}' +
+            '{"name":"arg3","value":function () { return createInteger(21); }}' +
             ']);' +
-            'return tools.valueFactory.createNull();' +
             '}'
         );
     });
@@ -135,18 +133,16 @@ describe('Transpiler closure expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.createClosure(' +
+            'function (core) {' +
+            'var createClosure = core.createClosure, createInteger = core.createInteger, echo = core.echo, getVariable = core.getVariable, setReferenceOrValue = core.setReferenceOrValue;' +
+            'return createClosure(' +
             'function ($myArg) {' +
-            'var scope = this;' +
-            'scope.getVariable("myArg").setReferenceOrValue($myArg);' +
-            'stdout.write(tools.valueFactory.createInteger(21).coerceToString().getNative());' +
+            'setReferenceOrValue(getVariable("myArg"), $myArg);' +
+            'echo(createInteger(21));' +
             '}, ' +
-            'scope, namespaceScope, [' +
-            '{"name":"myArg","ref":true,"value":function () { return tools.valueFactory.createInteger(27); }}' +
+            '[' +
+            '{"name":"myArg","ref":true,"value":function () { return createInteger(27); }}' +
             ']);' +
-            'return tools.valueFactory.createNull();' +
             '}'
         );
     });
@@ -170,13 +166,11 @@ describe('Transpiler closure expression test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.createClosure(' +
+            'function (core) {' +
+            'var createClosure = core.createClosure;' +
+            'return createClosure(' +
             'function () {' +
-            'var scope = this;' +
-            '}, scope, namespaceScope, [], true);' +
-            'return tools.valueFactory.createNull();' +
+            '}, [], true);' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/functionCallTest.js
+++ b/test/integration/transpiler/expressions/functionCallTest.js
@@ -1,0 +1,168 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler function call expression test', function () {
+    it('should correctly transpile a call with no arguments', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_FUNCTION_CALL',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myFunc'
+                    },
+                    args: []
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var callFunction = core.callFunction;' +
+            'callFunction("myFunc");' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a call to static function name having arguments with simple values', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_FUNCTION_CALL',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myFunc'
+                    },
+                    args: [{
+                        name: 'N_STRING_LITERAL',
+                        string: 'My string'
+                    }, {
+                        name: 'N_INTEGER',
+                        number: 21
+                    }, {
+                        name: 'N_FLOAT',
+                        number: 101.4
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var callFunction = core.callFunction, createFloat = core.createFloat, createInteger = core.createInteger, createString = core.createString;' +
+            'callFunction("myFunc", [' +
+            'createString("My string"), ' +
+            'createInteger(21), ' +
+            'createFloat(101.4)' +
+            ']);' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a call having arguments with complex values', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_FUNCTION_CALL',
+                    func: {
+                        name: 'N_STRING',
+                        string: 'myFunc'
+                    },
+                    args: [{
+                        name: 'N_ARRAY_LITERAL',
+                        elements: [{
+                            name: 'N_KEY_VALUE_PAIR',
+                            key: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'myVarElement'
+                            },
+                            value: {
+                                name: 'N_VARIABLE',
+                                variable: 'myVarInNamedElement'
+                            }
+                        }, {
+                            name: 'N_KEY_VALUE_PAIR',
+                            key: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'myPropertyElement'
+                            },
+                            value: {
+                                name: 'N_OBJECT_PROPERTY',
+                                object: {
+                                    name: 'N_VARIABLE',
+                                    variable: 'myObject'
+                                },
+                                property: {
+                                    name: 'N_STRING',
+                                    string: 'myProp'
+                                }
+                            }
+                        }, {
+                            name: 'N_VARIABLE',
+                            variable: 'myVarInIndexedElement'
+                        }]
+                    }, {
+                        name: 'N_VARIABLE',
+                        variable: 'myVarAsArg'
+                    }, {
+                        name: 'N_TERNARY',
+                        condition: {
+                            name: 'N_VARIABLE',
+                            variable: 'myVarAsCondition'
+                        },
+                        consequent: {
+                            name: 'N_STRING',
+                            string: 'show me if truthy'
+                        },
+                        alternate: {
+                            name: 'N_STRING',
+                            string: 'show me if falsy'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var callFunction = core.callFunction, createArray = core.createArray, createKeyValuePair = core.createKeyValuePair, createString = core.createString, getConstant = core.getConstant, getInstanceProperty = core.getInstanceProperty, getVariable = core.getVariable, ternary = core.ternary;' +
+            'callFunction("myFunc", [' +
+            'createArray([' +
+            'createKeyValuePair(' +
+            'createString("myVarElement"), ' +
+            'getVariable("myVarInNamedElement")' +
+            '), ' +
+            'createKeyValuePair(' +
+            'createString("myPropertyElement"), ' +
+            'getInstanceProperty(getVariable("myObject"), "myProp")' +
+            '), ' +
+            'getVariable("myVarInIndexedElement")' +
+            ']), ' +
+            'getVariable("myVarAsArg")' +
+            ', ' +
+            '(ternary(getVariable("myVarAsCondition")) ? ' +
+            'getConstant("show me if truthy") : ' +
+            'getConstant("show me if falsy")' +
+            ')' +
+            ']);' +
+            '}'
+        );
+    });
+});

--- a/test/integration/transpiler/expressions/includeOnceTest.js
+++ b/test/integration/transpiler/expressions/includeOnceTest.js
@@ -39,10 +39,9 @@ describe('Transpiler "include_once" expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("map").setValue(tools.includeOnce(tools.valueFactory.createString("abc.php").getNative(), scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, getVariable = core.getVariable, includeOnce = core.includeOnce, setValue = core.setValue;' +
+            'setValue(getVariable("map"), includeOnce(createString("abc.php")));' +
             '});'
         );
     });

--- a/test/integration/transpiler/expressions/includeTest.js
+++ b/test/integration/transpiler/expressions/includeTest.js
@@ -39,10 +39,9 @@ describe('Transpiler "include" expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("map").setValue(tools.include(tools.valueFactory.createString("abc.php").getNative(), scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, getVariable = core.getVariable, include = core.include, setValue = core.setValue;' +
+            'setValue(getVariable("map"), include(createString("abc.php")));' +
             '});'
         );
     });

--- a/test/integration/transpiler/expressions/instanceMethodCallTest.js
+++ b/test/integration/transpiler/expressions/instanceMethodCallTest.js
@@ -24,29 +24,28 @@ describe('Transpiler instance method call expression test', function () {
                         name: 'N_VARIABLE',
                         variable: 'myObject'
                     },
-                    calls: [{
-                        func: {
-                            name: 'N_STRING',
-                            string: 'myMethod'
-                        },
-                        args: [{
-                            name: 'N_VARIABLE',
-                            variable: 'myVar'
-                        }]
+                    method: {
+                        name: 'N_STRING',
+                        string: 'myMethod'
+                    },
+                    args: [{
+                        name: 'N_VARIABLE',
+                        variable: 'firstVar'
+                    }, {
+                        name: 'N_VARIABLE',
+                        variable: 'secondVar'
                     }]
                 }
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myObject").getValue().callMethod(' +
-            'tools.valueFactory.createBarewordString("myMethod").getNative(), [' +
-            'scope.getVariable("myVar")' +
-            ']' +
-            ');' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callInstanceMethod = core.callInstanceMethod, getVariable = core.getVariable;' +
+            'callInstanceMethod(getVariable("myObject"), "myMethod", [' +
+            'getVariable("firstVar"), ' +
+            'getVariable("secondVar")' +
+            ']);' +
             '});'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/classTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/classTest.js
@@ -68,14 +68,13 @@ describe('Transpiler __CLASS__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (core) {' +
             'var defineClass = core.defineClass, getClassName = core.getClassName;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
             'method: function _getClass() {' +
             'return getClassName();' +
             '}}' +
-            '}, constants: {}});}());' +
+            '}, constants: {}});' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/classTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/classTest.js
@@ -25,10 +25,9 @@ describe('Transpiler __CLASS__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getClassName();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getClassName = core.getClassName;' +
+            'return getClassName();' +
             '}'
         );
     });
@@ -67,17 +66,17 @@ describe('Transpiler __CLASS__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'function (core) {' +
+            'var defineClass = core.defineClass, getClassName = core.getClassName;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function _getClass() {var scope = this;' +
-            'return scope.getClassName();' +
+            'method: function _getClass() {' +
+            'return getClassName();' +
             '}}' +
-            '}, constants: {}}, namespaceScope);}());' +
-            'return tools.valueFactory.createNull();}'
+            '}, constants: {}});}());' +
+            '}'
         );
     });
 });

--- a/test/integration/transpiler/expressions/magicConstant/dirTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/dirTest.js
@@ -25,10 +25,9 @@ describe('Transpiler __DIR__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.getPathDirectory();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getPathDirectory = core.getPathDirectory;' +
+            'return getPathDirectory();' +
             '}'
         );
     });
@@ -60,12 +59,11 @@ describe('Transpiler __DIR__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function _myFunction() {var scope = this;' +
-            'return tools.getPathDirectory();' +
-            '}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var defineFunction = core.defineFunction, getPathDirectory = core.getPathDirectory;' +
+            'defineFunction("myFunction", function _myFunction() {' +
+            'return getPathDirectory();' +
+            '});' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/fileTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/fileTest.js
@@ -25,10 +25,9 @@ describe('Transpiler __FILE__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.getPath();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getPath = core.getPath;' +
+            'return getPath();' +
             '}'
         );
     });
@@ -60,12 +59,11 @@ describe('Transpiler __FILE__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function _myFunction() {var scope = this;' +
-            'return tools.getPath();' +
-            '}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var defineFunction = core.defineFunction, getPath = core.getPath;' +
+            'defineFunction("myFunction", function _myFunction() {' +
+            'return getPath();' +
+            '});' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/functionTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/functionTest.js
@@ -25,10 +25,9 @@ describe('Transpiler __FUNCTION__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getFunctionName();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getFunctionName = core.getFunctionName;' +
+            'return getFunctionName();' +
             '}'
         );
     });
@@ -60,12 +59,11 @@ describe('Transpiler __FUNCTION__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function _myFunction() {var scope = this;' +
-            'return scope.getFunctionName();' +
-            '}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var defineFunction = core.defineFunction, getFunctionName = core.getFunctionName;' +
+            'defineFunction("myFunction", function _myFunction() {' +
+            'return getFunctionName();' +
+            '});' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/lineTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/lineTest.js
@@ -31,10 +31,9 @@ describe('Transpiler __LINE__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(1);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(1);' +
             '}'
         );
     });
@@ -72,12 +71,30 @@ describe('Transpiler __LINE__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunction", function _myFunction() {var scope = this;' +
-            'return tools.valueFactory.createInteger(3);' +
-            '}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, defineFunction = core.defineFunction;' +
+            'defineFunction("myFunction", function _myFunction() {' +
+            'return createInteger(3);' +
+            '});' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a return statement outside of function with no bounds information', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_MAGIC_LINE_CONSTANT'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var nullValue = core.nullValue;' +
+            'return nullValue;' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/methodTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/methodTest.js
@@ -68,14 +68,13 @@ describe('Transpiler __METHOD__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (core) {' +
             'var defineClass = core.defineClass, getMethodName = core.getMethodName;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
             'method: function _getClass() {' +
             'return getMethodName();' +
             '}}' +
-            '}, constants: {}});}());' +
+            '}, constants: {}});' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/magicConstant/methodTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/methodTest.js
@@ -25,10 +25,9 @@ describe('Transpiler __METHOD__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getMethodName();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getMethodName = core.getMethodName;' +
+            'return getMethodName();' +
             '}'
         );
     });
@@ -67,17 +66,17 @@ describe('Transpiler __METHOD__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'function (core) {' +
+            'var defineClass = core.defineClass, getMethodName = core.getMethodName;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function _getClass() {var scope = this;' +
-            'return scope.getMethodName();' +
+            'method: function _getClass() {' +
+            'return getMethodName();' +
             '}}' +
-            '}, constants: {}}, namespaceScope);}());' +
-            'return tools.valueFactory.createNull();}'
+            '}, constants: {}});}());' +
+            '}'
         );
     });
 });

--- a/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
@@ -25,10 +25,9 @@ describe('Transpiler __NAMESPACE__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return namespaceScope.getNamespaceName();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getNamespaceName = core.getNamespaceName;' +
+            'return getNamespaceName();' +
             '}'
         );
     });
@@ -67,17 +66,17 @@ describe('Transpiler __NAMESPACE__ magic constant test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'function (core) {' +
+            'var defineClass = core.defineClass, getNamespaceName = core.getNamespaceName;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function _getClass() {var scope = this;' +
-            'return namespaceScope.getNamespaceName();' +
+            'method: function _getClass() {' +
+            'return getNamespaceName();' +
             '}}' +
-            '}, constants: {}}, namespaceScope);}());' +
-            'return tools.valueFactory.createNull();}'
+            '}, constants: {}});}());' +
+            '}'
         );
     });
 });

--- a/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
+++ b/test/integration/transpiler/expressions/magicConstant/namespaceTest.js
@@ -68,14 +68,13 @@ describe('Transpiler __NAMESPACE__ magic constant test', function () {
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
             'function (core) {' +
             'var defineClass = core.defineClass, getNamespaceName = core.getNamespaceName;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
             'method: function _getClass() {' +
             'return getNamespaceName();' +
             '}}' +
-            '}, constants: {}});}());' +
+            '}, constants: {}});' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/nullTest.js
+++ b/test/integration/transpiler/expressions/nullTest.js
@@ -12,24 +12,22 @@
 var expect = require('chai').expect,
     phpToJS = require('../../../..');
 
-describe('Transpiler literal expression test', function () {
-    it('should correctly transpile a return of boolean with non-lower case', function () {
+describe('Transpiler null expression test', function () {
+    it('should correctly transpile a return of null', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
                 name: 'N_RETURN_STATEMENT',
                 expression: {
-                    name: 'N_BOOLEAN',
-                    bool: 'tRUe'
+                    name: 'N_NULL'
                 }
             }]
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(true);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var nullValue = core.nullValue;' +
+            'return nullValue;' +
             '}'
         );
     });

--- a/test/integration/transpiler/expressions/numberLiteralTest.js
+++ b/test/integration/transpiler/expressions/numberLiteralTest.js
@@ -1,0 +1,55 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler number literal expression test', function () {
+    it('should correctly transpile a return of float', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_FLOAT',
+                    number: 101.123
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var createFloat = core.createFloat;' +
+            'return createFloat(101.123);' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a return of integer', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_INTEGER',
+                    number: 21
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(21);' +
+            '}'
+        );
+    });
+});

--- a/test/integration/transpiler/expressions/requireOnceTest.js
+++ b/test/integration/transpiler/expressions/requireOnceTest.js
@@ -39,10 +39,9 @@ describe('Transpiler "require_once" expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("map").setValue(tools.requireOnce(tools.valueFactory.createString("abc.php").getNative(), scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, getVariable = core.getVariable, requireOnce = core.requireOnce, setValue = core.setValue;' +
+            'setValue(getVariable("map"), requireOnce(createString("abc.php")));' +
             '});'
         );
     });

--- a/test/integration/transpiler/expressions/requireTest.js
+++ b/test/integration/transpiler/expressions/requireTest.js
@@ -39,10 +39,9 @@ describe('Transpiler "require" expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("map").setValue(tools.require(tools.valueFactory.createString("abc.php").getNative(), scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, getVariable = core.getVariable, require = core.require, setValue = core.setValue;' +
+            'setValue(getVariable("map"), require(createString("abc.php")));' +
             '});'
         );
     });

--- a/test/integration/transpiler/expressions/staticMethodCallTest.js
+++ b/test/integration/transpiler/expressions/staticMethodCallTest.js
@@ -37,13 +37,11 @@ describe('Transpiler static method call expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'tools.valueFactory.createBarewordString("\\\\My\\\\Space\\\\MyClass")' +
-            '.callStaticMethod(tools.valueFactory.createBarewordString("myMethod"), [' +
-            'scope.getVariable("myVar")' +
-            '], namespaceScope, false);' + // Non-forwarding
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callStaticMethod = core.callStaticMethod, createBareword = core.createBareword, getVariable = core.getVariable;' +
+            'callStaticMethod(createBareword("\\\\My\\\\Space\\\\MyClass"), "myMethod", [' +
+            'getVariable("myVar")' +
+            '], false);' + // Non-forwarding
             '});'
         );
     });

--- a/test/integration/transpiler/expressions/variable/variableInstanceMethodCallTest.js
+++ b/test/integration/transpiler/expressions/variable/variableInstanceMethodCallTest.js
@@ -1,0 +1,48 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../../index');
+
+describe('Transpiler variable instance method call expression test', function () {
+    it('should correctly transpile a call to instance method of variable', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_METHOD_CALL',
+                    object: {
+                        name: 'N_VARIABLE',
+                        variable: 'myObject'
+                    },
+                    method: {
+                        name: 'N_VARIABLE',
+                        variable: 'myMethodName'
+                    },
+                    args: [{
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callVariableInstanceMethod = core.callVariableInstanceMethod, getVariable = core.getVariable;' +
+            'callVariableInstanceMethod(getVariable("myObject"), getVariable("myMethodName"), [' +
+            'getVariable("myVar")' +
+            ']);' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/expressions/variable/variableStaticMethodCallTest.js
+++ b/test/integration/transpiler/expressions/variable/variableStaticMethodCallTest.js
@@ -1,0 +1,48 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../../index');
+
+describe('Transpiler variable static method call expression test', function () {
+    it('should correctly transpile a call to static method with FQCN (non-forwarding)', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_STATIC_METHOD_CALL',
+                    className: {
+                        name: 'N_STRING',
+                        string: '\\My\\Space\\MyClass'
+                    },
+                    method: {
+                        name: 'N_VARIABLE',
+                        variable: 'myMethodNameVar'
+                    },
+                    args: [{
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callVariableStaticMethod = core.callVariableStaticMethod, createBareword = core.createBareword, getVariable = core.getVariable;' +
+            'callVariableStaticMethod(createBareword("\\\\My\\\\Space\\\\MyClass"), getVariable("myMethodNameVar"), [' +
+            'getVariable("myVar")' +
+            '], false);' + // Non-forwarding
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/extensions/customStatementTest.js
+++ b/test/integration/transpiler/extensions/customStatementTest.js
@@ -49,7 +49,7 @@ describe('Transpiler custom statement test', function () {
                 nodes: {
                     'N_CUSTOM_TRAP_IT': function (node, interpret, context) {
                         return context.createStatementSourceNode(
-                            ['stdout.write("Trapped: " + ', interpret(node.arg, {getValue: true}), '.getNative());'],
+                            [context.useCoreSymbol('printRaw'), '("Trapped: " + ', context.useCoreSymbol('getNative'), '(', interpret(node.arg, {getValue: true}), '));'],
                             node
                         );
                     }
@@ -57,12 +57,11 @@ describe('Transpiler custom statement test', function () {
             };
 
         expect(phpToJS.transpile(ast, {}, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '(tools.valueFactory.createBarewordString("firstFunc").call([], namespaceScope) || tools.valueFactory.createNull());' +
-            'stdout.write("Trapped: " + tools.valueFactory.createInteger(21).getNative());' +
-            '(tools.valueFactory.createBarewordString("secondFunc").call([], namespaceScope) || tools.valueFactory.createNull());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callFunction = core.callFunction, createInteger = core.createInteger, getNative = core.getNative, printRaw = core.printRaw;' +
+            'callFunction("firstFunc");' +
+            'printRaw("Trapped: " + getNative(createInteger(21)));' +
+            'callFunction("secondFunc");' +
             '});'
         );
     });

--- a/test/integration/transpiler/extensions/customStatementTest.js
+++ b/test/integration/transpiler/extensions/customStatementTest.js
@@ -49,7 +49,7 @@ describe('Transpiler custom statement test', function () {
                 nodes: {
                     'N_CUSTOM_TRAP_IT': function (node, interpret, context) {
                         return context.createStatementSourceNode(
-                            [context.useCoreSymbol('printRaw'), '("Trapped: " + ', context.useCoreSymbol('getNative'), '(', interpret(node.arg, {getValue: true}), '));'],
+                            [context.useCoreSymbol('printRaw'), '("Trapped: " + ', context.useCoreSymbol('getNative'), '(', interpret(node.arg), '));'],
                             node
                         );
                     }

--- a/test/integration/transpiler/lineNumberTest.js
+++ b/test/integration/transpiler/lineNumberTest.js
@@ -255,6 +255,35 @@ describe('Transpiler line numbers test', function () {
                     name: 'N_CLASS_STATEMENT',
                     className: 'MyClass',
                     members: [{
+                        name: 'N_STATIC_PROPERTY_DEFINITION',
+                        visibility: 'private',
+                        variable: {
+                            name: 'N_VARIABLE',
+                            variable: 'myStaticProp',
+                            bounds: {
+                                start: {
+                                    line: 5,
+                                    column: 20
+                                }
+                            }
+                        },
+                        value: {
+                            name: 'N_STRING',
+                            string: 'MY_CONST',
+                            bounds: {
+                                start: {
+                                    line: 5,
+                                    column: 30
+                                }
+                            }
+                        },
+                        bounds: {
+                            start: {
+                                line: 5,
+                                column: 3
+                            }
+                        }
+                    }, {
                         name: 'N_METHOD_DEFINITION',
                         visibility: 'public',
                         func: {
@@ -453,24 +482,27 @@ describe('Transpiler line numbers test', function () {
 
         expect(phpToJS.transpile(ast, options)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
-            'var createClosure = core.createClosure, defineClass = core.defineClass, defineFunction = core.defineFunction, defineInterface = core.defineInterface, getVariable = core.getVariable, getVariableForScope = core.getVariableForScope, instrument = core.instrument, line, scope = core.scope, setValue = core.setValue;' +
+            'var createClosure = core.createClosure, defineClass = core.defineClass, defineFunction = core.defineFunction, defineInterface = core.defineInterface, getConstant = core.getConstant, getVariable = core.getVariable, getVariableForScope = core.getVariableForScope, instrument = core.instrument, line, scope = core.scope, setValue = core.setValue;' +
             'instrument(function () {return line;});' +
             'line = 3;defineFunction("myFunc", function _myFunc() {' +
             'var line;' +
             'instrument(function () {return line;});' +
             'line = 8;return (line = 8, getVariable("myFunctionVar"));' +
             '}, [], 3);' +
-            'line = 2;(function () {var currentClass = defineClass("MyClass", {' +
-            'superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'line = 2;defineClass("MyClass", {' +
+            'superClass: null, interfaces: [], staticProperties: {' +
+            // Note that line numbers are not included for property initialisers,
+            // as we always refer to the site they are referenced from
+            '"myStaticProp": {visibility: "private", value: function (currentClass) { return (line = 5, getConstant("MY_CONST")); }}' +
+            '}, properties: {}, methods: {' +
             '"myMethod": {' +
             'isStatic: false, method: function _myMethod() {' +
             'var line;' +
             'instrument(function () {return line;});' +
             'line = 8;return (line = 10, getVariable("myMethodVar"));' +
             '}, args: [], line: 11' +
-            '}}, constants: {}});}());' +
-            'line = 8;return (line = 1, getVariable("myGlobalCodeVar"));' +
-            'line = 3;(function () {var currentClass = defineInterface("MyThingInterface", {' +
+            '}}, constants: {}});' +
+            'line = 3;defineInterface("MyThingInterface", {' +
             'superClass: null, ' +
             'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
             'staticProperties: {}, ' +
@@ -480,7 +512,7 @@ describe('Transpiler line numbers test', function () {
             '}, ' +
             'constants: {}' +
             '});' +
-            '}());' +
+            'line = 8;return (line = 1, getVariable("myGlobalCodeVar"));' +
             'line = 8;return (line = 12, createClosure((function (parentScope) { return function ($myArgVar) {' +
             'var line;' +
             'instrument(function () {return line;});' +

--- a/test/integration/transpiler/lineNumberTest.js
+++ b/test/integration/transpiler/lineNumberTest.js
@@ -489,6 +489,16 @@ describe('Transpiler line numbers test', function () {
             'instrument(function () {return line;});' +
             'line = 8;return (line = 8, getVariable("myFunctionVar"));' +
             '}, [], 3);' +
+            'line = 3;defineInterface("MyThingInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
+            'staticProperties: {}, ' +
+            'properties: {}, ' +
+            'methods: {' +
+            '"doSomethingElse": {isStatic: false, abstract: true}' +
+            '}, ' +
+            'constants: {}' +
+            '});' +
             'line = 2;defineClass("MyClass", {' +
             'superClass: null, interfaces: [], staticProperties: {' +
             // Note that line numbers are not included for property initialisers,
@@ -502,16 +512,6 @@ describe('Transpiler line numbers test', function () {
             'line = 8;return (line = 10, getVariable("myMethodVar"));' +
             '}, args: [], line: 11' +
             '}}, constants: {}});' +
-            'line = 3;defineInterface("MyThingInterface", {' +
-            'superClass: null, ' +
-            'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
-            'staticProperties: {}, ' +
-            'properties: {}, ' +
-            'methods: {' +
-            '"doSomethingElse": {isStatic: false, abstract: true}' +
-            '}, ' +
-            'constants: {}' +
-            '});' +
             'line = 8;return (line = 1, getVariable("myGlobalCodeVar"));' +
             'line = 8;return (line = 12, createClosure((function (parentScope) { return function ($myArgVar) {' +
             'var line;' +

--- a/test/integration/transpiler/lineNumberTest.js
+++ b/test/integration/transpiler/lineNumberTest.js
@@ -493,7 +493,7 @@ describe('Transpiler line numbers test', function () {
             'superClass: null, interfaces: [], staticProperties: {' +
             // Note that line numbers are not included for property initialisers,
             // as we always refer to the site they are referenced from
-            '"myStaticProp": {visibility: "private", value: function (currentClass) { return (line = 5, getConstant("MY_CONST")); }}' +
+            '"myStaticProp": {visibility: "private", value: function (currentClass) { return getConstant("MY_CONST"); }}' +
             '}, properties: {}, methods: {' +
             '"myMethod": {' +
             'isStatic: false, method: function _myMethod() {' +

--- a/test/integration/transpiler/lineNumberTest.js
+++ b/test/integration/transpiler/lineNumberTest.js
@@ -48,11 +48,10 @@ describe('Transpiler line numbers test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 6;return (line = 8, tools.valueFactory.createInteger(4));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, instrument = core.instrument, line;' +
+            'instrument(function () {return line;});' +
+            'line = 6;return (line = 8, createInteger(4));' +
             '});'
         );
     });
@@ -102,11 +101,11 @@ describe('Transpiler line numbers test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 4;line = 6;return (line = 8, tools.valueFactory.createInteger(101));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, instrument = core.instrument, line, useGlobalNamespaceScope = core.useGlobalNamespaceScope;' +
+            'instrument(function () {return line;});' +
+            'line = 4;useGlobalNamespaceScope();' +
+            'line = 6;return (line = 8, createInteger(101));' +
             '});'
         );
     });
@@ -174,13 +173,12 @@ describe('Transpiler line numbers test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 6;block_1: while ((line = 8, scope.getVariable("myCond").getValue()).coerceToBoolean().getNative()) {' +
-            'line = 9;stdout.write((line = 9, scope.getVariable("myVar").getValue()).coerceToString().getNative());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var echo = core.echo, getVariable = core.getVariable, instrument = core.instrument, line, loop = core.loop;' +
+            'instrument(function () {return line;});' +
+            'line = 6;block_1: while (loop(0, (line = 8, getVariable("myCond")))) {' +
+            'line = 9;echo((line = 9, getVariable("myVar")));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -454,25 +452,25 @@ describe('Transpiler line numbers test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 3;namespace.defineFunction("myFunc", function _myFunc() {' +
-            'var scope = this;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 8;return (line = 8, scope.getVariable("myFunctionVar").getValue());' +
-            '}, namespaceScope, [], 3);' +
-            'line = 2;(function () {var currentClass = namespace.defineClass("MyClass", {' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createClosure = core.createClosure, defineClass = core.defineClass, defineFunction = core.defineFunction, defineInterface = core.defineInterface, getVariable = core.getVariable, getVariableForScope = core.getVariableForScope, instrument = core.instrument, line, scope = core.scope, setValue = core.setValue;' +
+            'instrument(function () {return line;});' +
+            'line = 3;defineFunction("myFunc", function _myFunc() {' +
+            'var line;' +
+            'instrument(function () {return line;});' +
+            'line = 8;return (line = 8, getVariable("myFunctionVar"));' +
+            '}, [], 3);' +
+            'line = 2;(function () {var currentClass = defineClass("MyClass", {' +
             'superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"myMethod": {' +
             'isStatic: false, method: function _myMethod() {' +
-            'var scope = this;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 8;return (line = 10, scope.getVariable("myMethodVar").getValue());' +
+            'var line;' +
+            'instrument(function () {return line;});' +
+            'line = 8;return (line = 10, getVariable("myMethodVar"));' +
             '}, args: [], line: 11' +
-            '}}, constants: {}}, namespaceScope);}());' +
-            'line = 8;return (line = 1, scope.getVariable("myGlobalCodeVar").getValue());' +
-            'line = 3;(function () {var currentClass = namespace.defineClass("MyThingInterface", {' +
+            '}}, constants: {}});}());' +
+            'line = 8;return (line = 1, getVariable("myGlobalCodeVar"));' +
+            'line = 3;(function () {var currentClass = defineInterface("MyThingInterface", {' +
             'superClass: null, ' +
             'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
             'staticProperties: {}, ' +
@@ -481,18 +479,17 @@ describe('Transpiler line numbers test', function () {
             '"doSomethingElse": {isStatic: false, abstract: true}' +
             '}, ' +
             'constants: {}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'line = 8;return (line = 12, tools.createClosure((function (parentScope) { return function ($myArgVar) {' +
-            'var scope = this;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'scope.getVariable("myArgVar").setValue($myArgVar.getValue());' +
-            'scope.getVariable("myBoundVar").setValue(parentScope.getVariable("myBoundVar").getValue());' +
-            'line = 8;return (line = 11, scope.getVariable("myClosureVar").getValue());' +
-            '}; }(scope)), scope, namespaceScope, [' +
+            'line = 8;return (line = 12, createClosure((function (parentScope) { return function ($myArgVar) {' +
+            'var line;' +
+            'instrument(function () {return line;});' +
+            'setValue(getVariable("myArgVar"), $myArgVar);' +
+            'setValue(getVariable("myBoundVar"), getVariableForScope("myBoundVar", parentScope));' +
+            'line = 8;return (line = 11, getVariable("myClosureVar"));' +
+            '}; }(scope)), [' +
             '{"name":"myArgVar"}' +
             '], false, 12));' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/modeOptionTest.js
+++ b/test/integration/transpiler/modeOptionTest.js
@@ -26,10 +26,9 @@ describe('Transpiler "mode" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {mode: 'sync'})).to.equal(
-            'require(\'phpruntime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime/sync\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });
@@ -47,10 +46,9 @@ describe('Transpiler "mode" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {mode: 'async'})).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });
@@ -68,10 +66,9 @@ describe('Transpiler "mode" option test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });
@@ -89,10 +86,9 @@ describe('Transpiler "mode" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {mode: 'psync'})).to.equal(
-            'require(\'phpruntime/psync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime/psync\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });

--- a/test/integration/transpiler/newTest.js
+++ b/test/integration/transpiler/newTest.js
@@ -39,10 +39,9 @@ describe('Transpiler new expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("object").setValue(tools.createInstance(namespaceScope, tools.valueFactory.createBarewordString("Worker"), []));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createBareword = core.createBareword, createInstance = core.createInstance, getVariable = core.getVariable, setValue = core.setValue;' +
+            'setValue(getVariable("object"), createInstance(createBareword("Worker"), []));' +
             '});'
         );
     });
@@ -70,12 +69,11 @@ describe('Transpiler new expression test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '(tools.valueFactory.createBarewordString("myFunc").call([' +
-            'tools.createInstance(namespaceScope, scope.getVariable("myClassName").getValue(), [])' +
-            '], namespaceScope) || tools.valueFactory.createNull());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callFunction = core.callFunction, createInstance = core.createInstance, getVariable = core.getVariable;' +
+            'callFunction("myFunc", [' +
+            'createInstance(getVariable("myClassName"), [])' +
+            ']);' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/arithmetic/additionOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/additionOperatorTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler addition arithmetic operator "+" test', function () {
+    it('should correctly transpile a return statement with operation', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: '21'
+                    },
+                    right: [{
+                        operator: '+',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: '10'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var add = core.add, createInteger = core.createInteger;' +
+            'return add(createInteger(21), createInteger(10));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/arithmetic/divisionOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/divisionOperatorTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler division arithmetic operator "/" test', function () {
+    it('should correctly transpile a return statement with operation', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: '21'
+                    },
+                    right: [{
+                        operator: '/',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: '10'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, divide = core.divide;' +
+            'return divide(createInteger(21), createInteger(10));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/arithmetic/identityOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/identityOperatorTest.js
@@ -1,0 +1,40 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler identity arithmetic operator "+" test', function () {
+    it('should correctly transpile a return statement with operation', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_UNARY_EXPRESSION',
+                    operator: '+',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    prefix: true
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, identity = core.identity;' +
+            'return identity(getVariable("myVar"));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/arithmetic/moduloOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/moduloOperatorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler modulo arithmetic operator "%" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).modulo(tools.valueFactory.createInteger(10));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, modulo = core.modulo;' +
+            'return modulo(createInteger(21), createInteger(10));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/arithmetic/multiplicationOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/multiplicationOperatorTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler multiplication arithmetic operator "*" test', function () {
+    it('should correctly transpile a return statement with operation', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: '21'
+                    },
+                    right: [{
+                        operator: '*',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: '10'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, multiply = core.multiply;' +
+            'return multiply(createInteger(21), createInteger(10));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/arithmetic/negationOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/negationOperatorTest.js
@@ -1,0 +1,40 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler negation arithmetic operator "-" test', function () {
+    it('should correctly transpile a return statement with operation', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_UNARY_EXPRESSION',
+                    operator: '-',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    prefix: true
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, negate = core.negate;' +
+            'return negate(getVariable("myVar"));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/arithmetic/subtractionOperatorTest.js
+++ b/test/integration/transpiler/operators/arithmetic/subtractionOperatorTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler subtraction arithmetic operator "-" test', function () {
+    it('should correctly transpile a return statement with operation', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: '21'
+                    },
+                    right: [{
+                        operator: '-',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: '10'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, subtract = core.subtract;' +
+            'return subtract(createInteger(21), createInteger(10));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/assignment/additionAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/additionAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler addition assignment operator "+=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").incrementBy(tools.valueFactory.createInteger(21));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, incrementBy = core.incrementBy;' +
+            'return incrementBy(getVariable("myVar"), createInteger(21));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/assignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/assignmentTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler reference assignment operator "=" test', function () {
+    it('should correctly transpile a return statement with assignment to variable', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    right: [{
+                        operator: '=',
+                        operand: {
+                            name: 'N_VARIABLE',
+                            variable: 'anotherVar'
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, setValue = core.setValue;' +
+            'return setValue(getVariable("myVar"), getVariable("anotherVar"));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/assignment/bitwiseAndAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/bitwiseAndAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise AND assignment operator "&=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").bitwiseAndWith(tools.valueFactory.createInteger(27));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var bitwiseAndWith = core.bitwiseAndWith, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'return bitwiseAndWith(getVariable("myVar"), createInteger(27));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/bitwiseLeftShiftAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/bitwiseLeftShiftAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise left-shift assignment operator "<<=" test', functio
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").shiftLeftBy(tools.valueFactory.createInteger(12));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, shiftLeftBy = core.shiftLeftBy;' +
+            'return shiftLeftBy(getVariable("myVar"), createInteger(12));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/bitwiseOrAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/bitwiseOrAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise OR assignment operator "|=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").bitwiseOrWith(tools.valueFactory.createInteger(27));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var bitwiseOrWith = core.bitwiseOrWith, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'return bitwiseOrWith(getVariable("myVar"), createInteger(27));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/bitwiseRightShiftAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/bitwiseRightShiftAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise right-shift assignment operator ">>=" test', functi
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").shiftRightBy(tools.valueFactory.createInteger(12));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, shiftRightBy = core.shiftRightBy;' +
+            'return shiftRightBy(getVariable("myVar"), createInteger(12));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/bitwiseXorAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/bitwiseXorAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise XOR assignment operator "^=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").bitwiseXorWith(tools.valueFactory.createInteger(27));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var bitwiseXorWith = core.bitwiseXorWith, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'return bitwiseXorWith(getVariable("myVar"), createInteger(27));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/concatenationAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/concatenationAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler string concatenation assignment operator ".=" test', functi
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").concatWith(tools.valueFactory.createString("my string here"));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var concatWith = core.concatWith, createString = core.createString, getVariable = core.getVariable;' +
+            'return concatWith(getVariable("myVar"), createString("my string here"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/divisionAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/divisionAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler division assignment operator "/=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").divideBy(tools.valueFactory.createInteger(27));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, divideBy = core.divideBy, getVariable = core.getVariable;' +
+            'return divideBy(getVariable("myVar"), createInteger(27));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/moduloAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/moduloAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler modulo assignment operator "%=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").moduloWith(tools.valueFactory.createInteger(21));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, moduloWith = core.moduloWith;' +
+            'return moduloWith(getVariable("myVar"), createInteger(21));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/multiplicationAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/multiplicationAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler multiplication assignment operator "*=" test', function () 
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").multiplyBy(tools.valueFactory.createInteger(21));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, multiplyBy = core.multiplyBy;' +
+            'return multiplyBy(getVariable("myVar"), createInteger(21));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/referenceAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/referenceAssignmentTest.js
@@ -39,10 +39,9 @@ describe('Transpiler reference assignment pseudo-operator "=&" test', function (
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").setReference(scope.getVariable("anotherVar").getReference());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, setReference = core.setReference;' +
+            'return setReference(getVariable("myVar"), getVariable("anotherVar"));' +
             '});'
         );
     });
@@ -83,10 +82,9 @@ describe('Transpiler reference assignment pseudo-operator "=&" test', function (
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("firstVar").setValue(scope.getVariable("secondVar").setReference(scope.getVariable("thirdVar").getReference()).getValue());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, setReference = core.setReference, setValue = core.setValue;' +
+            'return setValue(getVariable("firstVar"), setReference(getVariable("secondVar"), getVariable("thirdVar")));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/assignment/subtractionAssignmentTest.js
+++ b/test/integration/transpiler/operators/assignment/subtractionAssignmentTest.js
@@ -36,10 +36,9 @@ describe('Transpiler subtraction assignment operator "-=" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").decrementBy(tools.valueFactory.createInteger(21));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, decrementBy = core.decrementBy, getVariable = core.getVariable;' +
+            'return decrementBy(getVariable("myVar"), createInteger(21));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/bitwise/bitwiseAndOperatorTest.js
+++ b/test/integration/transpiler/operators/bitwise/bitwiseAndOperatorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise AND operator "&" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).bitwiseAnd(tools.valueFactory.createInteger(10));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var bitwiseAnd = core.bitwiseAnd, createInteger = core.createInteger;' +
+            'return bitwiseAnd(createInteger(21), createInteger(10));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/bitwise/bitwiseLeftShiftOperatorTest.js
+++ b/test/integration/transpiler/operators/bitwise/bitwiseLeftShiftOperatorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise left-shift operator "<<" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).shiftLeftBy(tools.valueFactory.createInteger(10));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, shiftLeft = core.shiftLeft;' +
+            'return shiftLeft(createInteger(21), createInteger(10));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/bitwise/bitwiseOrOperatorTest.js
+++ b/test/integration/transpiler/operators/bitwise/bitwiseOrOperatorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise OR operator "|" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).bitwiseOr(tools.valueFactory.createInteger(10));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var bitwiseOr = core.bitwiseOr, createInteger = core.createInteger;' +
+            'return bitwiseOr(createInteger(21), createInteger(10));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/bitwise/bitwiseRightShiftOperatorTest.js
+++ b/test/integration/transpiler/operators/bitwise/bitwiseRightShiftOperatorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise right-shift operator ">>" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).shiftRightBy(tools.valueFactory.createInteger(10));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, shiftRight = core.shiftRight;' +
+            'return shiftRight(createInteger(21), createInteger(10));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/bitwise/bitwiseXorOperatorTest.js
+++ b/test/integration/transpiler/operators/bitwise/bitwiseXorOperatorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler bitwise XOR operator "^" test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).bitwiseXor(tools.valueFactory.createInteger(10));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var bitwiseXor = core.bitwiseXor, createInteger = core.createInteger;' +
+            'return bitwiseXor(createInteger(21), createInteger(10));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/cast/arrayTest.js
+++ b/test/integration/transpiler/operators/cast/arrayTest.js
@@ -39,10 +39,9 @@ describe('Transpiler array cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToArray();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToArray = core.coerceToArray, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToArray(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/binaryTest.js
+++ b/test/integration/transpiler/operators/cast/binaryTest.js
@@ -39,13 +39,12 @@ describe('Transpiler binary cast operator test', function () {
         };
 
         // For now, just treat binary string and string values as identical,
-        // as Zend's engine doesn't seem to recognise the difference yet anyway
+        // as the reference engine doesn't seem to recognise the difference yet anyway
         // (was slated for PHP v6.)
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToString();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToString = core.coerceToString, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToString(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/booleanTest.js
+++ b/test/integration/transpiler/operators/cast/booleanTest.js
@@ -39,10 +39,9 @@ describe('Transpiler boolean cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToBoolean();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToBoolean = core.coerceToBoolean, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToBoolean(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/doubleTest.js
+++ b/test/integration/transpiler/operators/cast/doubleTest.js
@@ -39,10 +39,9 @@ describe('Transpiler double cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToFloat();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToFloat = core.coerceToFloat, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToFloat(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/integerTest.js
+++ b/test/integration/transpiler/operators/cast/integerTest.js
@@ -39,10 +39,9 @@ describe('Transpiler integer cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToInteger();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToInteger = core.coerceToInteger, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToInteger(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/objectTest.js
+++ b/test/integration/transpiler/operators/cast/objectTest.js
@@ -39,10 +39,9 @@ describe('Transpiler object cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToObject();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToObject = core.coerceToObject, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToObject(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/stringTest.js
+++ b/test/integration/transpiler/operators/cast/stringTest.js
@@ -39,10 +39,9 @@ describe('Transpiler string cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)).coerceToString();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, coerceToString = core.coerceToString, createInteger = core.createInteger, getVariable = core.getVariable;' +
+            'coerceToString(add(getVariable("myVar"), createInteger(21)));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cast/unsetTest.js
+++ b/test/integration/transpiler/operators/cast/unsetTest.js
@@ -39,10 +39,9 @@ describe('Transpiler unset cast operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '(scope.getVariable("myVar").getValue().add(tools.valueFactory.createInteger(21)), tools.valueFactory.createNull());' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, nullValue = core.nullValue;' +
+            '(add(getVariable("myVar"), createInteger(21)), nullValue);' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/cloneTest.js
+++ b/test/integration/transpiler/operators/cloneTest.js
@@ -29,10 +29,9 @@ describe('Transpiler clone operator test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myObject").getValue().clone();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var clone = core.clone, getVariable = core.getVariable;' +
+            'return clone(getVariable("myObject"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/comparison/greaterThanOrEqualTest.js
+++ b/test/integration/transpiler/operators/comparison/greaterThanOrEqualTest.js
@@ -36,10 +36,9 @@ describe('Transpiler greater-than-or-equal comparison operator test', function (
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).isGreaterThanOrEqual(tools.valueFactory.createInteger(32));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, isGreaterThanOrEqual = core.isGreaterThanOrEqual;' +
+            'return isGreaterThanOrEqual(createInteger(21), createInteger(32));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/comparison/greaterThanTest.js
+++ b/test/integration/transpiler/operators/comparison/greaterThanTest.js
@@ -36,10 +36,9 @@ describe('Transpiler greater-than comparison operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).isGreaterThan(tools.valueFactory.createInteger(32));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, isGreaterThan = core.isGreaterThan;' +
+            'return isGreaterThan(createInteger(21), createInteger(32));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/comparison/lessThanOrEqualTest.js
+++ b/test/integration/transpiler/operators/comparison/lessThanOrEqualTest.js
@@ -36,10 +36,9 @@ describe('Transpiler less-than-or-equal comparison operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).isLessThanOrEqual(tools.valueFactory.createInteger(32));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, isLessThanOrEqual = core.isLessThanOrEqual;' +
+            'return isLessThanOrEqual(createInteger(21), createInteger(32));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/comparison/lessThanTest.js
+++ b/test/integration/transpiler/operators/comparison/lessThanTest.js
@@ -36,10 +36,9 @@ describe('Transpiler less-than comparison operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).isLessThan(tools.valueFactory.createInteger(32));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, isLessThan = core.isLessThan;' +
+            'return isLessThan(createInteger(21), createInteger(32));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/comparison/looseEqualityTest.js
+++ b/test/integration/transpiler/operators/comparison/looseEqualityTest.js
@@ -1,0 +1,45 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler loose equality comparison operator test', function () {
+    it('should correctly transpile a return with a comparison between two integers', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    right: [{
+                        operator: '==',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 32
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var createInteger = core.createInteger, isEqual = core.isEqual;' +
+            'return isEqual(createInteger(21), createInteger(32));' +
+            '}'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/comparison/looseInequalityTest.js
+++ b/test/integration/transpiler/operators/comparison/looseInequalityTest.js
@@ -13,7 +13,37 @@ var expect = require('chai').expect,
     phpToJS = require('../../../../..');
 
 describe('Transpiler loose inequality comparison operator test', function () {
-    it('should correctly transpile a return with a comparison between two integers', function () {
+    it('should correctly transpile a return with a comparison using "!=" between two integers', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    right: [{
+                        operator: '!=',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 32
+                        }
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var createInteger = core.createInteger, isNotEqual = core.isNotEqual;' +
+            'return isNotEqual(createInteger(21), createInteger(32));' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a return with a comparison using "<>" between two integers', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -36,10 +66,9 @@ describe('Transpiler loose inequality comparison operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(21).isNotEqualTo(tools.valueFactory.createInteger(32));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, isNotEqual = core.isNotEqual;' +
+            'return isNotEqual(createInteger(21), createInteger(32));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/decrementTest.js
+++ b/test/integration/transpiler/operators/decrementTest.js
@@ -1,0 +1,65 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler decrement "--" operator test', function () {
+    it('should correctly transpile a pre-decrement expression statement', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_UNARY_EXPRESSION',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    operator: '--',
+                    prefix: true
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, preDecrement = core.preDecrement;' +
+            'preDecrement(getVariable("myVar"));' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a post-decrement expression statement', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_UNARY_EXPRESSION',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    operator: '--',
+                    prefix: false
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, postDecrement = core.postDecrement;' +
+            'postDecrement(getVariable("myVar"));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/errorControlTest.js
+++ b/test/integration/transpiler/operators/errorControlTest.js
@@ -29,12 +29,9 @@ describe('Transpiler error control operator @(...) test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (function (scope) {scope.suppressErrors();' +
-            'var result = scope.getVariable("myVar").getValue();' +
-            'scope.unsuppressErrors(); return result;}(scope));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, suppressErrors = core.suppressErrors;' +
+            'return suppressErrors()(getVariable("myVar"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/incrementTest.js
+++ b/test/integration/transpiler/operators/incrementTest.js
@@ -1,0 +1,65 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler increment "++" operator test', function () {
+    it('should correctly transpile a pre-increment expression statement', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_UNARY_EXPRESSION',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    operator: '++',
+                    prefix: true
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, preIncrement = core.preIncrement;' +
+            'preIncrement(getVariable("myVar"));' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a post-increment expression statement', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_EXPRESSION_STATEMENT',
+                expression: {
+                    name: 'N_UNARY_EXPRESSION',
+                    operand: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVar'
+                    },
+                    operator: '++',
+                    prefix: false
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, postIncrement = core.postIncrement;' +
+            'postIncrement(getVariable("myVar"));' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/instanceOfTest.js
+++ b/test/integration/transpiler/operators/instanceOfTest.js
@@ -33,10 +33,9 @@ describe('Transpiler instanceof binary operator test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myObject").getValue().isAnInstanceOf(scope.getVariable("myClass").getValue(), namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable, instanceOf = core.instanceOf;' +
+            'return instanceOf(getVariable("myObject"), getVariable("myClass"));' +
             '});'
         );
     });
@@ -61,10 +60,9 @@ describe('Transpiler instanceof binary operator test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myObject").getValue().isAnInstanceOf(tools.valueFactory.createBarewordString("MyClass"), namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createBareword = core.createBareword, getVariable = core.getVariable, instanceOf = core.instanceOf;' +
+            'return instanceOf(getVariable("myObject"), createBareword("MyClass"));' +
             '});'
         );
     });
@@ -96,12 +94,9 @@ describe('Transpiler instanceof binary operator test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return (tools.valueFactory.createBarewordString("myFunc").call([scope.getVariable("myObject").getValue().isAnInstanceOf(' +
-            'tools.valueFactory.createBarewordString("MyClass"), namespaceScope' +
-            ')], namespaceScope) || tools.valueFactory.createNull());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callFunction = core.callFunction, createBareword = core.createBareword, getVariable = core.getVariable, instanceOf = core.instanceOf;' +
+            'return callFunction("myFunc", [instanceOf(getVariable("myObject"), createBareword("MyClass"))]);' +
             '});'
         );
     });

--- a/test/integration/transpiler/operators/logical/andTest.js
+++ b/test/integration/transpiler/operators/logical/andTest.js
@@ -36,10 +36,9 @@ describe('Transpiler logical "and" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(tools.valueFactory.createString("first").coerceToBoolean().getNative() && (tools.valueFactory.createString("second").coerceToBoolean().getNative()));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createBoolean = core.createBoolean, createString = core.createString, logicalTerm = core.logicalTerm;' +
+            'return createBoolean(logicalTerm(createString("first")) && logicalTerm(createString("second")));' +
             '}'
         );
     });
@@ -67,10 +66,9 @@ describe('Transpiler logical "and" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(tools.valueFactory.createString("first").coerceToBoolean().getNative() && (tools.valueFactory.createString("second").coerceToBoolean().getNative()));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createBoolean = core.createBoolean, createString = core.createString, logicalTerm = core.logicalTerm;' +
+            'return createBoolean(logicalTerm(createString("first")) && logicalTerm(createString("second")));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/logical/notTest.js
+++ b/test/integration/transpiler/operators/logical/notTest.js
@@ -31,10 +31,9 @@ describe('Transpiler logical "not" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("myVar").getValue().logicalNot();' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getVariable = core.getVariable, logicalNot = core.logicalNot;' +
+            'return logicalNot(getVariable("myVar"));' +
             '}'
         );
     });
@@ -67,10 +66,9 @@ describe('Transpiler logical "not" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return scope.getVariable("leftVar").getValue().logicalNot().isNotIdenticalTo(scope.getVariable("rightVar").getValue());' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getVariable = core.getVariable, isNotIdentical = core.isNotIdentical, logicalNot = core.logicalNot;' +
+            'return isNotIdentical(logicalNot(getVariable("leftVar")), getVariable("rightVar"));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/logical/orTest.js
+++ b/test/integration/transpiler/operators/logical/orTest.js
@@ -36,10 +36,9 @@ describe('Transpiler logical "or" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(tools.valueFactory.createString("first").coerceToBoolean().getNative() || (tools.valueFactory.createString("second").coerceToBoolean().getNative()));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createBoolean = core.createBoolean, createString = core.createString, logicalTerm = core.logicalTerm;' +
+            'return createBoolean(logicalTerm(createString("first")) || logicalTerm(createString("second")));' +
             '}'
         );
     });
@@ -77,15 +76,9 @@ describe('Transpiler logical "or" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(' +
-            'tools.valueFactory.createInteger(21).coerceToBoolean().getNative() || (' +
-            'tools.valueFactory.createBoolean(tools.valueFactory.createInteger(27).coerceToBoolean().getNative() || (' +
-            'tools.valueFactory.createInteger(101).coerceToBoolean().getNative())).coerceToBoolean().getNative()' +
-            ')' +
-            ');' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createBoolean = core.createBoolean, createInteger = core.createInteger, logicalTerm = core.logicalTerm;' +
+            'return createBoolean(logicalTerm(createInteger(21)) || logicalTerm(createBoolean(logicalTerm(createInteger(27)) || logicalTerm(createInteger(101)))));' +
             '}'
         );
     });
@@ -113,10 +106,9 @@ describe('Transpiler logical "or" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(tools.valueFactory.createString("first").coerceToBoolean().getNative() || (tools.valueFactory.createString("second").coerceToBoolean().getNative()));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createBoolean = core.createBoolean, createString = core.createString, logicalTerm = core.logicalTerm;' +
+            'return createBoolean(logicalTerm(createString("first")) || logicalTerm(createString("second")));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/logical/xorTest.js
+++ b/test/integration/transpiler/operators/logical/xorTest.js
@@ -36,10 +36,9 @@ describe('Transpiler logical "xor" operator test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBoolean(tools.valueFactory.createString("first").coerceToBoolean().getNative() !== (tools.valueFactory.createString("second").coerceToBoolean().getNative()));' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createString = core.createString, logicalXor = core.logicalXor;' +
+            'return logicalXor(createString("first"), createString("second"));' +
             '}'
         );
     });

--- a/test/integration/transpiler/operators/nullCoalescingTest.js
+++ b/test/integration/transpiler/operators/nullCoalescingTest.js
@@ -1,0 +1,42 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler null coalescing operator (??) test', function () {
+    it('should correctly transpile a return of null-coalescing expression', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_NULL_COALESCE',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: '21'
+                    },
+                    right: {
+                        name: 'N_INTEGER',
+                        number: '22'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var createInteger = core.createInteger, nullCoalesce = core.nullCoalesce;' +
+            'return nullCoalesce()(createInteger(21), createInteger(22));' +
+            '}'
+        );
+    });
+});

--- a/test/integration/transpiler/operators/scopeResolution/staticPropertyTest.js
+++ b/test/integration/transpiler/operators/scopeResolution/staticPropertyTest.js
@@ -1,0 +1,103 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler static property access test', function () {
+    it('should correctly transpile a read of a property of a statically-given class (via bareword)', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STATIC_PROPERTY',
+                    className: {
+                        name: 'N_STRING',
+                        string: 'MyImportedClass'
+                    },
+                    property: {
+                        name: 'N_STRING',
+                        string: 'myStaticProp'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var createBareword = core.createBareword, getStaticProperty = core.getStaticProperty;' +
+            'return getStaticProperty(createBareword("MyImportedClass"), "myStaticProp");' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a read of a property of a property of a dynamically-given class (via variable)', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STATIC_PROPERTY',
+                    className: {
+                        name: 'N_STATIC_PROPERTY',
+                        className: {
+                            name: 'N_VARIABLE',
+                            variable: 'myVar'
+                        },
+                        property: {
+                            name: 'N_STRING',
+                            string: 'firstProp'
+                        }
+                    },
+                    property: {
+                        name: 'N_STRING',
+                        string: 'secondProp'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var getStaticProperty = core.getStaticProperty, getVariable = core.getVariable;' +
+            'return getStaticProperty(getStaticProperty(getVariable("myVar"), "firstProp"), "secondProp");' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a dynamic reference to a property', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_STATIC_PROPERTY',
+                    className: {
+                        name: 'N_VARIABLE',
+                        variable: 'myClassNameVar'
+                    },
+                    property: {
+                        name: 'N_VARIABLE',
+                        variable: 'myVarHoldingPropName'
+                    }
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var getVariable = core.getVariable, getVariableStaticProperty = core.getVariableStaticProperty;' +
+            'return getVariableStaticProperty(getVariable("myClassNameVar"), getVariable("myVarHoldingPropName"));' +
+            '}'
+        );
+    });
+});

--- a/test/integration/transpiler/printTest.js
+++ b/test/integration/transpiler/printTest.js
@@ -21,19 +21,17 @@ describe('Transpiler "print" expression test', function () {
                 expression: {
                     name: 'N_PRINT_EXPRESSION',
                     operand: {
-                        name: 'N_STRING',
-                        string: 'hello'
+                        name: 'N_STRING_LITERAL',
+                        string: 'hello world'
                     }
                 }
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '(stdout.write(namespaceScope.getConstant("hello").coerceToString().getNative()), ' +
-            'tools.valueFactory.createInteger(1));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, print = core.print;' +
+            'print(createString("hello world"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/returnTest.js
+++ b/test/integration/transpiler/returnTest.js
@@ -22,10 +22,8 @@ describe('Transpiler "return" statement test', function () {
             };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createNull();' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'return;' +
             '});'
         );
     });
@@ -43,10 +41,9 @@ describe('Transpiler "return" statement test', function () {
             };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(4);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(4);' +
             '});'
         );
     });
@@ -64,10 +61,29 @@ describe('Transpiler "return" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(6);' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(6);' +
+            '}'
+        );
+    });
+
+    it('should correctly transpile a return statement of variable value in bare mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_RETURN_STATEMENT',
+                expression: {
+                    name: 'N_VARIABLE',
+                    variable: 'myVar'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast, {bare: true})).to.equal(
+            'function (core) {' +
+            'var getVariable = core.getVariable;' +
+            'return getVariable("myVar");' +
             '}'
         );
     });

--- a/test/integration/transpiler/runtimePathOptionTest.js
+++ b/test/integration/transpiler/runtimePathOptionTest.js
@@ -12,7 +12,7 @@
 var expect = require('chai').expect,
     phpToJS = require('../../..');
 
-describe('Transpiler "return" statement test', function () {
+describe('Transpiler "runtimePath" option test', function () {
     it('should correctly transpile a return statement with an operand of 4 in default (async) mode', function () {
         var ast = {
             name: 'N_PROGRAM',
@@ -26,10 +26,9 @@ describe('Transpiler "return" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {runtimePath: '/path/to/runtime'})).to.equal(
-            'require(\'/path/to/runtime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(4);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'/path/to/runtime\').compile(function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(4);' +
             '});'
         );
     });
@@ -47,10 +46,9 @@ describe('Transpiler "return" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {sync: true, runtimePath: '/path/to/runtime'})).to.equal(
-            'require(\'/path/to/runtime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(6);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'/path/to/runtime/sync\').compile(function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(6);' +
             '});'
         );
     });
@@ -68,10 +66,9 @@ describe('Transpiler "return" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {mode: 'sync', runtimePath: '/path/to/runtime'})).to.equal(
-            'require(\'/path/to/runtime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(6);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'/path/to/runtime/sync\').compile(function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(6);' +
             '});'
         );
     });

--- a/test/integration/transpiler/scopeResolutionOperatorTest.js
+++ b/test/integration/transpiler/scopeResolutionOperatorTest.js
@@ -30,10 +30,9 @@ describe('Transpiler scope resolution operator test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createBarewordString("MyClass").getConstantByName("MY_CONST", namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createBareword = core.createBareword, getClassConstant = core.getClassConstant;' +
+            'return getClassConstant(createBareword("MyClass"), "MY_CONST");' +
             '});'
         );
     });

--- a/test/integration/transpiler/sourceMapTest.js
+++ b/test/integration/transpiler/sourceMapTest.js
@@ -50,14 +50,13 @@ describe('Transpiler source map test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(4);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(4);' +
             '});' +
-            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15' +
-            'X21vZHVsZS5waHAiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6InVNQU9TLE9BQVUsbUNBQVYsQyIsInNvdXJjZXNDb2' +
-            '50ZW50IjpbIjw/cGhwICR0aGlzID0gXCJpcyBteSBzb3VyY2UgUEhQXCI7Il19' +
+            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm' +
+            '15X21vZHVsZS5waHAiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6InNGQU9TLE9BQVUsZ0JBQVYsQyIsInNvdXJjZX' +
+            'NDb250ZW50IjpbIjw/cGhwICR0aGlzID0gXCJpcyBteSBzb3VyY2UgUEhQXCI7Il19' +
             '\n'
         );
     });
@@ -100,13 +99,12 @@ describe('Transpiler source map test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.deep.equal({
-            code: 'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createInteger(4);' +
-            'return tools.valueFactory.createNull();' +
+            code: 'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger;' +
+            'return createInteger(4);' +
             '});',
             map: {
-                mappings: 'uMAOS,OAAU,mCAAV,C',
+                mappings: 'sFAOS,OAAU,gBAAV,C',
                 names: [],
                 sources: [
                     'my_module.php'
@@ -335,45 +333,43 @@ describe('Transpiler source map test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createClosure = core.createClosure, createDebugVar = core.createDebugVar, defineClass = core.defineClass, defineFunction = core.defineFunction, getVariable = core.getVariable, getVariableForScope = core.getVariableForScope, scope = core.scope, setValue = core.setValue;' +
             // Debug variable will be inserted for better debugging in Chrome dev tools
-            'var $myGlobalCodeVar = tools.createDebugVar(scope, "myGlobalCodeVar");' +
-            'namespace.defineFunction("myFunc", function _myFunc() {' +
-            'var scope = this;' +
-            'var $this = tools.createDebugVar(scope, "this");' +
-            'var $myFunctionVar = tools.createDebugVar(scope, "myFunctionVar");' +
-            'return scope.getVariable("myFunctionVar").getValue();' +
-            '}, namespaceScope);' +
-            '(function () {var currentClass = namespace.defineClass("MyClass", {' +
+            'var $myGlobalCodeVar = createDebugVar("myGlobalCodeVar");' +
+            'defineFunction("myFunc", function _myFunc() {' +
+            'var $this = createDebugVar("this");' +
+            'var $myFunctionVar = createDebugVar("myFunctionVar");' +
+            'return getVariable("myFunctionVar");' +
+            '});' +
+            '(function () {var currentClass = defineClass("MyClass", {' +
             'superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"myMethod": {' +
             'isStatic: false, method: function _myMethod() {' +
-            'var scope = this;var $this = tools.createDebugVar(scope, "this");' +
-            'var $myMethodVar = tools.createDebugVar(scope, "myMethodVar");' +
-            'return scope.getVariable("myMethodVar").getValue();' +
+            'var $this = createDebugVar("this");' +
+            'var $myMethodVar = createDebugVar("myMethodVar");' +
+            'return getVariable("myMethodVar");' +
             '}' +
-            '}}, constants: {}}, namespaceScope);}());' +
-            'return scope.getVariable("myGlobalCodeVar").getValue();' +
-            'return tools.createClosure((function (parentScope) { return function ($myArgVar) {' +
-            'var scope = this;scope.getVariable("myArgVar").setValue($myArgVar.getValue());' +
-            'var $myArgVar = tools.createDebugVar(scope, "myArgVar");' +
-            'var $this = tools.createDebugVar(scope, "this");' +
-            'var $myClosureVar = tools.createDebugVar(scope, "myClosureVar");' +
-            'scope.getVariable("myBoundVar").setValue(parentScope.getVariable("myBoundVar").getValue());' +
-            'var $myBoundVar = tools.createDebugVar(scope, "myBoundVar");' +
-            'return scope.getVariable("myClosureVar").getValue();' +
-            '}; }(scope)), scope, namespaceScope, [' +
+            '}}, constants: {}});}());' +
+            'return getVariable("myGlobalCodeVar");' +
+            'return createClosure((function (parentScope) { return function ($myArgVar) {' +
+            'setValue(getVariable("myArgVar"), $myArgVar);' +
+            'var $myArgVar = createDebugVar("myArgVar");' +
+            'var $this = createDebugVar("this");' +
+            'var $myClosureVar = createDebugVar("myClosureVar");' +
+            'setValue(getVariable("myBoundVar"), getVariableForScope("myBoundVar", parentScope));' +
+            'var $myBoundVar = createDebugVar("myBoundVar");' +
+            'return getVariable("myClosureVar");' +
+            '}; }(scope)), [' +
             '{"name":"myArgVar"}' +
             ']);' +
-            'return tools.valueFactory.createNull();' +
             '});' +
-            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm15X21' +
-            'vZHVsZS5waHAiXSwibmFtZXMiOlsiTl9TVFJJTkciLCIkbXlGdW5jdGlvblZhciIsIiRteU1ldGhvZFZhciIsIiRteUds' +
-            'b2JhbENvZGVWYXIiLCIkbXlCb3VuZFZhciIsIiRteUNsb3N1cmVWYXIiXSwibWFwcGluZ3MiOiI2UUFFSyw0Q0FBQUEsT' +
-            '0FBQSx1SUFLSSxPQUFVQyw2Q0FBVixDQUxKLG1CQURJLGlLQVNJLG1DQUxORCxTQUtNLG1JQUhNLE9BQUFFLDJDQUFBLE' +
-            'NBR04sRUFUSix3Q0FNQSxPQUFVQywrQ0FBVixDQUFVLHVhQUFBQyxXQUFBLG9EQUFBQyw0Q0FBQSw2RCIsInNvdXJjZXN' +
-            'Db250ZW50IjpbIjw/cGhwICR0aGlzID0gXCJpcyBteSBzb3VyY2UgUEhQXCI7Il19' +
+            '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1' +
+            '5X21vZHVsZS5waHAiXSwibmFtZXMiOlsiTl9TVFJJTkciLCIkbXlGdW5jdGlvblZhciIsIiRteU1ldGhvZFZhciIs' +
+            'IiRteUdsb2JhbENvZGVWYXIiLCIkbXlCb3VuZFZhciIsIiRteUNsb3N1cmVWYXIiXSwibWFwcGluZ3MiOiJ5WEFFS' +
+            'yxrQ0FBQUEsT0FBQSw0RkFLSSxPQUFVQyw0QkFBVixDQUxKLEdBREksdUpBU0ksbUNBTE5ELFNBS00sd0ZBSE0sT0' +
+            'FBQUUsMEJBQUEsQ0FHTixFQVRKLHdCQU1BLE9BQVVDLDhCQUFWLENBQVUsa1ZBQUFDLFdBQUEsdUNBQUFDLDJCQUF' +
+            'BLHNDIiwic291cmNlc0NvbnRlbnQiOlsiPD9waHAgJHRoaXMgPSBcImlzIG15IHNvdXJjZSBQSFBcIjsiXX0=' +
             '\n'
         );
     });

--- a/test/integration/transpiler/sourceMapTest.js
+++ b/test/integration/transpiler/sourceMapTest.js
@@ -61,7 +61,7 @@ describe('Transpiler source map test', function () {
         );
     });
 
-    it('should correctly transpile a simple return statement in default (async) mode wih returnMap option', function () {
+    it('should correctly transpile a simple return statement in default (async) mode with returnMap option', function () {
         var ast = {
                 name: 'N_PROGRAM',
                 statements: [{
@@ -342,7 +342,7 @@ describe('Transpiler source map test', function () {
             'var $myFunctionVar = createDebugVar("myFunctionVar");' +
             'return getVariable("myFunctionVar");' +
             '});' +
-            '(function () {var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"myMethod": {' +
             'isStatic: false, method: function _myMethod() {' +
@@ -350,7 +350,7 @@ describe('Transpiler source map test', function () {
             'var $myMethodVar = createDebugVar("myMethodVar");' +
             'return getVariable("myMethodVar");' +
             '}' +
-            '}}, constants: {}});}());' +
+            '}}, constants: {}});' +
             'return getVariable("myGlobalCodeVar");' +
             'return createClosure((function (parentScope) { return function ($myArgVar) {' +
             'setValue(getVariable("myArgVar"), $myArgVar);' +
@@ -367,8 +367,8 @@ describe('Transpiler source map test', function () {
             '\n\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1' +
             '5X21vZHVsZS5waHAiXSwibmFtZXMiOlsiTl9TVFJJTkciLCIkbXlGdW5jdGlvblZhciIsIiRteU1ldGhvZFZhciIs' +
             'IiRteUdsb2JhbENvZGVWYXIiLCIkbXlCb3VuZFZhciIsIiRteUNsb3N1cmVWYXIiXSwibWFwcGluZ3MiOiJ5WEFFS' +
-            'yxrQ0FBQUEsT0FBQSw0RkFLSSxPQUFVQyw0QkFBVixDQUxKLEdBREksdUpBU0ksbUNBTE5ELFNBS00sd0ZBSE0sT0' +
-            'FBQUUsMEJBQUEsQ0FHTixFQVRKLHdCQU1BLE9BQVVDLDhCQUFWLENBQVUsa1ZBQUFDLFdBQUEsdUNBQUFDLDJCQUF' +
+            'yxrQ0FBQUEsT0FBQSw0RkFLSSxPQUFVQyw0QkFBVixDQUxKLEdBREksc0hBU0ksbUNBTE5ELFNBS00sd0ZBSE0sT0' +
+            'FBQUUsMEJBQUEsQ0FHTixFQVRKLG1CQU1BLE9BQVVDLDhCQUFWLENBQVUsa1ZBQUFDLFdBQUEsdUNBQUFDLDJCQUF' +
             'BLHNDIiwic291cmNlc0NvbnRlbnQiOlsiPD9waHAgJHRoaXMgPSBcImlzIG15IHNvdXJjZSBQSFBcIjsiXX0=' +
             '\n'
         );

--- a/test/integration/transpiler/stackCleaningOptionTest.js
+++ b/test/integration/transpiler/stackCleaningOptionTest.js
@@ -26,10 +26,9 @@ describe('Transpiler "stackCleaning" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {stackCleaning: true})).to.equal(
-            'require(\'phpruntime\').compile(function __uniterModuleStackMarker__(stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function __uniterModuleStackMarker__(core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });
@@ -52,10 +51,9 @@ describe('Transpiler "stackCleaning" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {stackCleaning: true})).to.equal(
-            'require(\'phpruntime\').compile(function __uniterModuleStackMarker__(stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("gogo", function _gogo__uniterFunctionStackMarker__() {var scope = this;}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function __uniterModuleStackMarker__(core) {' +
+            'var defineFunction = core.defineFunction;' +
+            'defineFunction("gogo", function _gogo__uniterFunctionStackMarker__() {});' +
             '});'
         );
     });
@@ -73,10 +71,9 @@ describe('Transpiler "stackCleaning" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {stackCleaning: false})).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });
@@ -99,10 +96,9 @@ describe('Transpiler "stackCleaning" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {stackCleaning: false})).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("gogo", function _gogo() {var scope = this;}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineFunction = core.defineFunction;' +
+            'defineFunction("gogo", function _gogo() {});' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/breakTest.js
+++ b/test/integration/transpiler/statements/breakTest.js
@@ -222,11 +222,11 @@ describe('Transpiler "break" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, switchCase = core.switchCase, switchOn = core.switchOn;' +
-            'block_1: {' +
             'var switchExpression_1 = switchOn(createInteger(21)), ' +
             'switchMatched_1 = false;' +
+            'block_1: {' +
             'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'break block_1;' +
             '}' +
             '}' +

--- a/test/integration/transpiler/statements/breakTest.js
+++ b/test/integration/transpiler/statements/breakTest.js
@@ -79,16 +79,15 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, isLessThan = core.isLessThan, loop = core.loop, postIncrement = core.postIncrement, setValue = core.setValue;' +
             'block_1: for (' +
-            'scope.getVariable("i").setValue(tools.valueFactory.createInteger(0));' +
-            'scope.getVariable("i").getValue().isLessThan(tools.valueFactory.createInteger(2)).coerceToBoolean().getNative();' +
-            'scope.getVariable("i").postIncrement()' +
+            'setValue(getVariable("i"), createInteger(0));' +
+            'loop(0, isLessThan(getVariable("i"), createInteger(2)));' +
+            'postIncrement(getVariable("i"))' +
             ') {' +
             'break block_1;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -117,16 +116,15 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var advance = core.advance, getCurrentElementValue = core.getCurrentElementValue, getIterator = core.getIterator, getVariable = core.getVariable, isNotFinished = core.isNotFinished, setValue = core.setValue;' +
             '' +
-            'block_1: for (var iterator_1 = scope.getVariable("myArray").getValue().getIterator(); ' +
-            'iterator_1.isNotFinished(); ' +
-            'iterator_1.advance()) {' +
-            'scope.getVariable("item").setValue(iterator_1.getCurrentElementValue());' +
+            'block_1: for (var iterator_1 = getIterator(getVariable("myArray")); ' +
+            'isNotFinished(0, iterator_1); ' +
+            'advance(iterator_1)) {' +
+            'setValue(getVariable("item"), getCurrentElementValue(iterator_1));' +
             'break block_1;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -154,12 +152,11 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: while (tools.valueFactory.createInteger(21).coerceToBoolean().getNative()) {' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, loop = core.loop;' +
+            'block_1: while (loop(0, createInteger(21))) {' +
             'break block_1;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -187,12 +184,11 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, loop = core.loop;' +
             'block_1: do {' +
             'break block_1;' +
-            '} while (tools.valueFactory.createInteger(21).coerceToBoolean().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            '} while (loop(0, createInteger(21)));' +
             '});'
         );
     });
@@ -224,17 +220,16 @@ describe('Transpiler "break" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, switchCase = core.switchCase, switchOn = core.switchOn;' +
             'block_1: {' +
-            'var switchExpression_1 = tools.valueFactory.createInteger(21), ' +
+            'var switchExpression_1 = switchOn(createInteger(21)), ' +
             'switchMatched_1 = false;' +
-            'if (switchMatched_1 || switchExpression_1.isEqualTo(tools.valueFactory.createInteger(21)).getNative()) {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
             'switchMatched_1 = true; ' +
             'break block_1;' +
             '}' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/abstractTest.js
+++ b/test/integration/transpiler/statements/class/abstractTest.js
@@ -82,19 +82,18 @@ describe('Transpiler class statement with abstract methods test', function () {
 
         // Abstract method definitions are discarded for now
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("AbstractMyClass", {' +
+            'var currentClass = defineClass("AbstractMyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/abstractTest.js
+++ b/test/integration/transpiler/statements/class/abstractTest.js
@@ -84,8 +84,7 @@ describe('Transpiler class statement with abstract methods test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var defineClass = core.defineClass;' +
-            '(function () {' +
-            'var currentClass = defineClass("AbstractMyClass", {' +
+            'defineClass("AbstractMyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
@@ -93,7 +92,6 @@ describe('Transpiler class statement with abstract methods test', function () {
             'methods: {}, ' +
             'constants: {}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/constantTest.js
+++ b/test/integration/transpiler/statements/class/constantTest.js
@@ -55,10 +55,10 @@ describe('Transpiler class statement with constants test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, getCurrentClassConstant = core.getCurrentClassConstant;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
@@ -66,18 +66,17 @@ describe('Transpiler class statement with constants test', function () {
             'methods: {}, ' +
             'constants: {' +
             '"MY_CONST": function () { ' +
-            'return tools.valueFactory.createInteger(1001); ' +
+            'return createInteger(1001); ' +
             '}, ' +
             '"ANOTHER_ONE": function () { ' +
-            'return currentClass.getConstantByName("MY_CONST", namespaceScope); ' +
+            'return getCurrentClassConstant(currentClass, "MY_CONST"); ' +
             '}, ' +
             '"YET_ANOTHER_ONE": function () { ' +
-            'return tools.valueFactory.createInteger(1234); ' +
+            'return createInteger(1234); ' +
             '}' +
             '}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/constantTest.js
+++ b/test/integration/transpiler/statements/class/constantTest.js
@@ -57,26 +57,24 @@ describe('Transpiler class statement with constants test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass, getCurrentClassConstant = core.getCurrentClassConstant;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {' +
-            '"MY_CONST": function () { ' +
+            '"MY_CONST": function (currentClass) { ' +
             'return createInteger(1001); ' +
             '}, ' +
-            '"ANOTHER_ONE": function () { ' +
+            '"ANOTHER_ONE": function (currentClass) { ' +
             'return getCurrentClassConstant(currentClass, "MY_CONST"); ' +
             '}, ' +
-            '"YET_ANOTHER_ONE": function () { ' +
+            '"YET_ANOTHER_ONE": function (currentClass) { ' +
             'return createInteger(1234); ' +
             '}' +
             '}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/extendsTest.js
+++ b/test/integration/transpiler/statements/class/extendsTest.js
@@ -27,8 +27,7 @@ describe('Transpiler class statement "extends" test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var defineClass = core.defineClass;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: "My\\\\SuperClass", ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
@@ -36,7 +35,6 @@ describe('Transpiler class statement "extends" test', function () {
             'methods: {}, ' +
             'constants: {}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/extendsTest.js
+++ b/test/integration/transpiler/statements/class/extendsTest.js
@@ -1,0 +1,43 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../../..');
+
+describe('Transpiler class statement "extends" test', function () {
+    it('should correctly transpile an empty class that extends another', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CLASS_STATEMENT',
+                className: 'MyClass',
+                extend: 'My\\SuperClass',
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass;' +
+            '(function () {' +
+            'var currentClass = defineClass("MyClass", {' +
+            'superClass: "My\\\\SuperClass", ' +
+            'interfaces: [], ' +
+            'staticProperties: {}, ' +
+            'properties: {}, ' +
+            'methods: {}, ' +
+            'constants: {}' +
+            '});' +
+            '}());' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/statements/class/methodDefinitionTest.js
+++ b/test/integration/transpiler/statements/class/methodDefinitionTest.js
@@ -82,10 +82,10 @@ describe('Transpiler class statement with method definitions test', function () 
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, getVariable = core.getVariable, setReference = core.setReference, setValue = core.setValue;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
@@ -93,25 +93,22 @@ describe('Transpiler class statement with method definitions test', function () 
             'methods: {' +
             '"myInstanceMethod": {' +
             'isStatic: false, method: function _myInstanceMethod($myByRefArrayArg) {' +
-            'var scope = this;' +
-            'scope.getVariable("myByRefArrayArg").setReference($myByRefArrayArg.getReference());' +
-            'return tools.valueFactory.createInteger(21);' +
+            'setReference(getVariable("myByRefArrayArg"), $myByRefArrayArg);' +
+            'return createInteger(21);' +
             '}, args: [' +
             '{"type":"array","name":"myByRefArrayArg","ref":true}' +
             ']}, ' +
             '"myStaticMethod": {' +
             'isStatic: true, method: function _myStaticMethod($myCallableArg) {' +
-            'var scope = this;' +
-            'scope.getVariable("myCallableArg").setValue($myCallableArg.getValue());' +
-            'return tools.valueFactory.createInteger(101);' +
+            'setValue(getVariable("myCallableArg"), $myCallableArg);' +
+            'return createInteger(101);' +
             '}, args: [' +
             '{"type":"array","name":"myCallableArg"}' +
             ']}' +
             '}, ' +
             'constants: {}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/methodDefinitionTest.js
+++ b/test/integration/transpiler/statements/class/methodDefinitionTest.js
@@ -84,8 +84,7 @@ describe('Transpiler class statement with method definitions test', function () 
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass, getVariable = core.getVariable, setReference = core.setReference, setValue = core.setValue;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
@@ -108,7 +107,6 @@ describe('Transpiler class statement with method definitions test', function () 
             '}, ' +
             'constants: {}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/propertyTest.js
+++ b/test/integration/transpiler/statements/class/propertyTest.js
@@ -44,18 +44,17 @@ describe('Transpiler class statement with properties test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {' +
-            '"firstProp": {visibility: "private", value: function () { return null; }}, ' +
-            '"secondProp": {visibility: "private", value: function () { return createInteger(21); }}' +
+            '"firstProp": {visibility: "private", value: function (currentClass) { return null; }}, ' +
+            '"secondProp": {visibility: "private", value: function (currentClass) { return createInteger(21); }}' +
             '}, ' +
             'methods: {}, ' +
             'constants: {}' +
-            '});}());' +
+            '});' +
             '});'
         );
     });
@@ -91,8 +90,7 @@ describe('Transpiler class statement with properties test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {' +
@@ -108,7 +106,7 @@ describe('Transpiler class statement with properties test', function () {
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {}' +
-            '});}());' +
+            '});' +
             '});'
         );
     });
@@ -152,24 +150,22 @@ describe('Transpiler class statement with properties test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass, getCurrentClassConstant = core.getCurrentClassConstant;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {' +
-            '"myProp": {visibility: "protected", value: function () { ' +
+            '"myProp": {visibility: "protected", value: function (currentClass) { ' +
             'return getCurrentClassConstant(currentClass, "MY_CONST"); ' +
             '}}' +
             '}, ' +
             'methods: {}, ' +
             'constants: {' +
-            '"MY_CONST": function () { ' +
+            '"MY_CONST": function (currentClass) { ' +
             'return createInteger(1001); ' +
             '}' +
             '}' +
             '});' +
-            '}());' +
             '});'
         );
     });
@@ -213,8 +209,7 @@ describe('Transpiler class statement with properties test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass, getCurrentClassConstant = core.getCurrentClassConstant;' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            'defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {' +
@@ -227,12 +222,11 @@ describe('Transpiler class statement with properties test', function () {
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {' +
-            '"MY_CONST": function () { ' +
+            '"MY_CONST": function (currentClass) { ' +
             'return createInteger(1001); ' +
             '}' +
             '}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/class/propertyTest.js
+++ b/test/integration/transpiler/statements/class/propertyTest.js
@@ -42,21 +42,20 @@ describe('Transpiler class statement with properties test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {' +
             '"firstProp": {visibility: "private", value: function () { return null; }}, ' +
-            '"secondProp": {visibility: "private", value: function () { return tools.valueFactory.createInteger(21); }}' +
+            '"secondProp": {visibility: "private", value: function () { return createInteger(21); }}' +
             '}, ' +
             'methods: {}, ' +
             'constants: {}' +
-            '}, namespaceScope);}());' +
-            'return tools.valueFactory.createNull();' +
+            '});}());' +
             '});'
         );
     });
@@ -90,27 +89,26 @@ describe('Transpiler class statement with properties test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {' +
             '"firstProp": {' +
             'visibility: "private", ' +
-            'value: function (currentClass) { return tools.valueFactory.createNull(); }' +
+            'value: function (currentClass) { return null; }' +
             '}, ' +
             '"secondProp": {' +
             'visibility: "private", ' +
-            'value: function (currentClass) { return tools.valueFactory.createInteger(21); }' +
+            'value: function (currentClass) { return createInteger(21); }' +
             '}' +
             '}, ' +
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {}' +
-            '}, namespaceScope);}());' +
-            'return tools.valueFactory.createNull();' +
+            '});}());' +
             '});'
         );
     });
@@ -152,27 +150,26 @@ describe('Transpiler class statement with properties test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, getCurrentClassConstant = core.getCurrentClassConstant;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {}, ' +
             'properties: {' +
             '"myProp": {visibility: "protected", value: function () { ' +
-            'return currentClass.getConstantByName("MY_CONST", namespaceScope); ' +
+            'return getCurrentClassConstant(currentClass, "MY_CONST"); ' +
             '}}' +
             '}, ' +
             'methods: {}, ' +
             'constants: {' +
             '"MY_CONST": function () { ' +
-            'return tools.valueFactory.createInteger(1001); ' +
+            'return createInteger(1001); ' +
             '}' +
             '}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -214,29 +211,28 @@ describe('Transpiler class statement with properties test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, getCurrentClassConstant = core.getCurrentClassConstant;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
+            'var currentClass = defineClass("MyClass", {' +
             'superClass: null, ' +
             'interfaces: [], ' +
             'staticProperties: {' +
             '"myStaticProp": {' +
             'visibility: "private", ' +
             'value: function (currentClass) { ' +
-            'return currentClass.getConstantByName("MY_CONST", namespaceScope); ' +
+            'return getCurrentClassConstant(currentClass, "MY_CONST"); ' +
             '}' +
             '}}, ' +
             'properties: {}, ' +
             'methods: {}, ' +
             'constants: {' +
             '"MY_CONST": function () { ' +
-            'return tools.valueFactory.createInteger(1001); ' +
+            'return createInteger(1001); ' +
             '}' +
             '}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/constantTest.js
+++ b/test/integration/transpiler/statements/constantTest.js
@@ -35,11 +35,10 @@ describe('Transpiler "const" declaration statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineConstant("FIRST_CONST", tools.valueFactory.createInteger(101));' +
-            'namespace.defineConstant("SECOND_CONST", tools.valueFactory.createString("hello world!"));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, createString = core.createString, defineConstant = core.defineConstant;' +
+            'defineConstant("FIRST_CONST", createInteger(101));' +
+            'defineConstant("SECOND_CONST", createString("hello world!"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/continueTest.js
+++ b/test/integration/transpiler/statements/continueTest.js
@@ -79,16 +79,15 @@ describe('Transpiler "continue" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, getVariable = core.getVariable, isLessThan = core.isLessThan, loop = core.loop, postIncrement = core.postIncrement, setValue = core.setValue;' +
             'block_1: for (' +
-            'scope.getVariable("i").setValue(tools.valueFactory.createInteger(0));' +
-            'scope.getVariable("i").getValue().isLessThan(tools.valueFactory.createInteger(2)).coerceToBoolean().getNative();' +
-            'scope.getVariable("i").postIncrement()' +
+            'setValue(getVariable("i"), createInteger(0));' +
+            'loop(0, isLessThan(getVariable("i"), createInteger(2)));' +
+            'postIncrement(getVariable("i"))' +
             ') {' +
             'continue block_1;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -117,16 +116,15 @@ describe('Transpiler "continue" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var advance = core.advance, getCurrentElementValue = core.getCurrentElementValue, getIterator = core.getIterator, getVariable = core.getVariable, isNotFinished = core.isNotFinished, setValue = core.setValue;' +
             '' +
-            'block_1: for (var iterator_1 = scope.getVariable("myArray").getValue().getIterator(); ' +
-            'iterator_1.isNotFinished(); ' +
-            'iterator_1.advance()) {' +
-            'scope.getVariable("item").setValue(iterator_1.getCurrentElementValue());' +
+            'block_1: for (var iterator_1 = getIterator(getVariable("myArray")); ' +
+            'isNotFinished(0, iterator_1); ' +
+            'advance(iterator_1)) {' +
+            'setValue(getVariable("item"), getCurrentElementValue(iterator_1));' +
             'continue block_1;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -154,12 +152,11 @@ describe('Transpiler "continue" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: while (tools.valueFactory.createInteger(21).coerceToBoolean().getNative()) {' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, loop = core.loop;' +
+            'block_1: while (loop(0, createInteger(21))) {' +
             'continue block_1;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -187,12 +184,11 @@ describe('Transpiler "continue" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, loop = core.loop;' +
             'block_1: do {' +
             'continue block_1;' +
-            '} while (tools.valueFactory.createInteger(21).coerceToBoolean().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            '} while (loop(0, createInteger(21)));' +
             '});'
         );
     });
@@ -225,17 +221,16 @@ describe('Transpiler "continue" statement test', function () {
 
         // In PHP, `continue` inside a `switch` should behave the save as a `break`
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, switchCase = core.switchCase, switchOn = core.switchOn;' +
             'block_1: {' +
-            'var switchExpression_1 = tools.valueFactory.createInteger(21), ' +
+            'var switchExpression_1 = switchOn(createInteger(21)), ' +
             'switchMatched_1 = false;' +
-            'if (switchMatched_1 || switchExpression_1.isEqualTo(tools.valueFactory.createInteger(21)).getNative()) {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
             'switchMatched_1 = true; ' +
             'break block_1;' +
             '}' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/continueTest.js
+++ b/test/integration/transpiler/statements/continueTest.js
@@ -223,11 +223,11 @@ describe('Transpiler "continue" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, switchCase = core.switchCase, switchOn = core.switchOn;' +
-            'block_1: {' +
             'var switchExpression_1 = switchOn(createInteger(21)), ' +
             'switchMatched_1 = false;' +
+            'block_1: {' +
             'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'break block_1;' +
             '}' +
             '}' +

--- a/test/integration/transpiler/statements/echoTest.js
+++ b/test/integration/transpiler/statements/echoTest.js
@@ -29,11 +29,10 @@ describe('Transpiler echo statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'stdout.write(scope.getVariable("firstVar").getValue().coerceToString().getNative());' +
-            'stdout.write(scope.getVariable("secondVar").getValue().coerceToString().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var echo = core.echo, getVariable = core.getVariable;' +
+            'echo(getVariable("firstVar"));' +
+            'echo(getVariable("secondVar"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/forTest.js
+++ b/test/integration/transpiler/statements/forTest.js
@@ -78,16 +78,15 @@ describe('Transpiler "for" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, echo = core.echo, getVariable = core.getVariable, isLessThan = core.isLessThan, loop = core.loop, postIncrement = core.postIncrement, setValue = core.setValue;' +
             'block_1: for (' +
-            'scope.getVariable("i").setValue(tools.valueFactory.createInteger(0));' +
-            'scope.getVariable("i").getValue().isLessThan(tools.valueFactory.createInteger(2)).coerceToBoolean().getNative();' +
-            'scope.getVariable("i").postIncrement()' +
+            'setValue(getVariable("i"), createInteger(0));' +
+            'loop(0, isLessThan(getVariable("i"), createInteger(2)));' +
+            'postIncrement(getVariable("i"))' +
             ') {' +
-            'stdout.write(scope.getVariable("i").getValue().coerceToString().getNative());' +
+            'echo(getVariable("i"));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -123,12 +122,11 @@ describe('Transpiler "for" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: for (;;) {' +
-            'stdout.write(scope.getVariable("i").getValue().coerceToString().getNative());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var echo = core.echo, getVariable = core.getVariable, loop = core.loop;' +
+            'block_1: for (;loop(0);) {' +
+            'echo(getVariable("i"));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/foreachTest.js
+++ b/test/integration/transpiler/statements/foreachTest.js
@@ -37,16 +37,14 @@ describe('Transpiler "foreach" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '' +
-            'block_1: for (var iterator_1 = scope.getVariable("myArray").getValue().getIterator(); ' +
-            'iterator_1.isNotFinished(); ' +
-            'iterator_1.advance()) {' +
-            'scope.getVariable("item").setValue(iterator_1.getCurrentElementValue());' +
-            'stdout.write(tools.valueFactory.createInteger(1).coerceToString().getNative());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var advance = core.advance, createInteger = core.createInteger, echo = core.echo, getCurrentElementValue = core.getCurrentElementValue, getIterator = core.getIterator, getVariable = core.getVariable, isNotFinished = core.isNotFinished, setValue = core.setValue;' +
+            'block_1: for (var iterator_1 = getIterator(getVariable("myArray")); ' +
+            'isNotFinished(0, iterator_1); ' +
+            'advance(iterator_1)) {' +
+            'setValue(getVariable("item"), getCurrentElementValue(iterator_1));' +
+            'echo(createInteger(1));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -78,15 +76,14 @@ describe('Transpiler "foreach" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: for (var iterator_1 = scope.getVariable("myArray").getValue().getIterator(); ' +
-            'iterator_1.isNotFinished(); ' +
-            'iterator_1.advance()) {' +
-            'scope.getVariable("item").setReference(iterator_1.getCurrentElementReference());' +
-            'stdout.write(tools.valueFactory.createInteger(1).coerceToString().getNative());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var advance = core.advance, createInteger = core.createInteger, echo = core.echo, getCurrentElementReference = core.getCurrentElementReference, getIterator = core.getIterator, getVariable = core.getVariable, isNotFinished = core.isNotFinished, setReference = core.setReference;' +
+            'block_1: for (var iterator_1 = getIterator(getVariable("myArray")); ' +
+            'isNotFinished(0, iterator_1); ' +
+            'advance(iterator_1)) {' +
+            'setReference(getVariable("item"), getCurrentElementReference(iterator_1));' +
+            'echo(createInteger(1));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -119,16 +116,15 @@ describe('Transpiler "foreach" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: for (var iterator_1 = scope.getVariable("myArray").getValue().getIterator(); ' +
-            'iterator_1.isNotFinished(); ' +
-            'iterator_1.advance()) {' +
-            'scope.getVariable("item").setValue(iterator_1.getCurrentElementValue());' +
-            'scope.getVariable("theKey").setValue(iterator_1.getCurrentKey());' +
-            'stdout.write(tools.valueFactory.createInteger(1).coerceToString().getNative());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var advance = core.advance, createInteger = core.createInteger, echo = core.echo, getCurrentElementValue = core.getCurrentElementValue, getCurrentKey = core.getCurrentKey, getIterator = core.getIterator, getVariable = core.getVariable, isNotFinished = core.isNotFinished, setValue = core.setValue;' +
+            'block_1: for (var iterator_1 = getIterator(getVariable("myArray")); ' +
+            'isNotFinished(0, iterator_1); ' +
+            'advance(iterator_1)) {' +
+            'setValue(getVariable("item"), getCurrentElementValue(iterator_1));' +
+            'setValue(getVariable("theKey"), getCurrentKey(iterator_1));' +
+            'echo(createInteger(1));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/globalTest.js
+++ b/test/integration/transpiler/statements/globalTest.js
@@ -29,10 +29,9 @@ describe('Transpiler global import statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'scope.importGlobal("firstVar");scope.importGlobal("secondVar");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var importGlobal = core.importGlobal;' +
+            'importGlobal("firstVar");importGlobal("secondVar");' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/gotoTest.js
+++ b/test/integration/transpiler/statements/gotoTest.js
@@ -52,24 +52,23 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo;' +
             'var goingToLabel_my_goto_label = false;' +
             'break_my_goto_label: {' +
                 'if (!goingToLabel_my_goto_label) {' +
-                    'stdout.write(tools.valueFactory.createString("Let us begin...").coerceToString().getNative());' +
+                    'echo(createString("Let us begin..."));' +
                 '}' +
                 'if (!goingToLabel_my_goto_label) {' +
                     'goingToLabel_my_goto_label = true; ' +
                     'break break_my_goto_label;' +
                 '}' +
                 'if (!goingToLabel_my_goto_label) {' +
-                    'stdout.write(tools.valueFactory.createString("... continue...").coerceToString().getNative());' +
+                    'echo(createString("... continue..."));' +
                 '}' +
             '}' +
             'goingToLabel_my_goto_label = false;' +
-            'stdout.write(tools.valueFactory.createString("... and let us finish").coerceToString().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            'echo(createString("... and let us finish"));' +
             '});'
         );
     });
@@ -111,20 +110,19 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo;' +
             'var goingToLabel_my_goto_label = false;' +
             'continue_my_goto_label: do {' +
                 'if (!goingToLabel_my_goto_label) {' +
-                    'stdout.write(tools.valueFactory.createString("Let us begin...").coerceToString().getNative());' +
+                    'echo(createString("Let us begin..."));' +
                 '}' +
                 'goingToLabel_my_goto_label = false;' +
-                'stdout.write(tools.valueFactory.createString("... continue...").coerceToString().getNative());' +
+                'echo(createString("... continue..."));' +
                 'goingToLabel_my_goto_label = true; ' +
                 'continue continue_my_goto_label;' +
-                'stdout.write(tools.valueFactory.createString("... and let us finish").coerceToString().getNative());' +
+                'echo(createString("... and let us finish"));' +
             '} while (goingToLabel_my_goto_label);' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -172,8 +170,8 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo;' +
             'var goingToLabel_my_goto_label = false;' +
             'break_my_goto_label: {' +
                 'if (!goingToLabel_my_goto_label) {' +
@@ -181,19 +179,18 @@ describe('Transpiler "goto" statement test', function () {
                     'break break_my_goto_label;' +
                 '}' +
                 'if (!goingToLabel_my_goto_label) {' +
-                    'stdout.write(tools.valueFactory.createString("I am in between...").coerceToString().getNative());' +
+                    'echo(createString("I am in between..."));' +
                 '}' +
                 'if (!goingToLabel_my_goto_label) {' +
                     'goingToLabel_my_goto_label = true; ' +
                     'break break_my_goto_label;' +
                 '}' +
                 'if (!goingToLabel_my_goto_label) {' +
-                    'stdout.write(tools.valueFactory.createString("... I am also...").coerceToString().getNative());' +
+                    'echo(createString("... I am also..."));' +
                 '}' +
             '}' +
             'goingToLabel_my_goto_label = false;' +
-            'stdout.write(tools.valueFactory.createString("... and we are done").coerceToString().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            'echo(createString("... and we are done"));' +
             '});'
         );
     });
@@ -241,20 +238,19 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo;' +
             'var goingToLabel_my_goto_label = false;' +
             'continue_my_goto_label: do {' +
                 'goingToLabel_my_goto_label = false;' +
-                'stdout.write(tools.valueFactory.createString("I am in between...").coerceToString().getNative());' +
+                'echo(createString("I am in between..."));' +
                 'goingToLabel_my_goto_label = true; ' +
                 'continue continue_my_goto_label;' +
-                'stdout.write(tools.valueFactory.createString("... I am also...").coerceToString().getNative());' +
+                'echo(createString("... I am also..."));' +
                 'goingToLabel_my_goto_label = true; ' +
                 'continue continue_my_goto_label;' +
-                'stdout.write(tools.valueFactory.createString("... and we are done").coerceToString().getNative());' +
+                'echo(createString("... and we are done"));' +
             '} while (goingToLabel_my_goto_label);' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -339,20 +335,20 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-                'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+                'var createString = core.createString, echo = core.echo;' +
                 'var goingToLabel_first_label = false, goingToLabel_second_label = false;' +
                 'break_second_label: {' +
                     'break_first_label: {' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
-                            'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                            'echo(createString("first"));' +
                         '}' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
                             'goingToLabel_first_label = true; ' +
                             'break break_first_label;' +
                         '}' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
-                            'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
+                            'echo(createString("second"));' +
                         '}' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
                             'goingToLabel_second_label = true; ' +
@@ -363,15 +359,14 @@ describe('Transpiler "goto" statement test', function () {
                         'goingToLabel_first_label = false;' +
                     '}' +
                     'if (!goingToLabel_second_label) {' +
-                        'stdout.write(tools.valueFactory.createString("third").coerceToString().getNative());' +
+                        'echo(createString("third"));' +
                     '}' +
                     'if (!goingToLabel_second_label) {' +
-                        'stdout.write(tools.valueFactory.createString("fourth").coerceToString().getNative());' +
+                        'echo(createString("fourth"));' +
                     '}' +
                 '}' +
                 'goingToLabel_second_label = false;' +
-                'stdout.write(tools.valueFactory.createString("fifth").coerceToString().getNative());' +
-                'return tools.valueFactory.createNull();' +
+                'echo(createString("fifth"));' +
             '});'
         );
     });
@@ -463,38 +458,37 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-                'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+                'var createString = core.createString, echo = core.echo, nullValue = core.nullValue;' +
                 'var goingToLabel_second_label = false, goingToLabel_first_label = false;' +
                 'continue_first_label: do {' +
                     'break_second_label: {' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
-                            'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                            'echo(createString("first"));' +
                         '}' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
                             'goingToLabel_second_label = true; ' +
                             'break break_second_label;' +
                         '}' +
                         'if (!goingToLabel_first_label && !goingToLabel_second_label) {' +
-                            'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
+                            'echo(createString("second"));' +
                         '}' +
                         'if (!goingToLabel_second_label) {' +
                             'goingToLabel_first_label = false;' +
                         '}' +
                         'if (!goingToLabel_second_label) {' +
-                            'stdout.write(tools.valueFactory.createString("third").coerceToString().getNative());' +
+                            'echo(createString("third"));' +
                         '}' +
                         'if (!goingToLabel_second_label) {' +
-                            'return tools.valueFactory.createNull();' +
+                            'return nullValue;' +
                         '}' +
                     '}' +
                     'goingToLabel_second_label = false;' +
-                    'stdout.write(tools.valueFactory.createString("fourth").coerceToString().getNative());' +
+                    'echo(createString("fourth"));' +
                     'goingToLabel_first_label = true; ' +
                     'continue continue_first_label;' +
-                    'stdout.write(tools.valueFactory.createString("fifth").coerceToString().getNative());' +
+                    'echo(createString("fifth"));' +
                 '} while (goingToLabel_first_label);' +
-                'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -534,22 +528,21 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, echo = core.echo, getVariable = core.getVariable, loop = core.loop;' +
             'var goingToLabel_my_label = false;' +
-            'block_1: while (scope.getVariable("myCondition").getValue().coerceToBoolean().getNative()) {' +
+            'block_1: while (loop(0, getVariable("myCondition"))) {' +
                 'break_my_label: {' +
                     'if (!goingToLabel_my_label) {' +
                         'goingToLabel_my_label = true; ' +
                         'break break_my_label;' +
                     '}' +
                     'if (!goingToLabel_my_label) {' +
-                        'stdout.write(tools.valueFactory.createInteger(4).coerceToString().getNative());' +
+                        'echo(createInteger(4));' +
                     '}' +
                 '}' +
                 'goingToLabel_my_label = false;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -589,8 +582,8 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, echo = core.echo, getVariable = core.getVariable, loop = core.loop;' +
             'var goingToLabel_my_label = false;' +
             'block_1: do {' +
                 'break_my_label: {' +
@@ -599,12 +592,11 @@ describe('Transpiler "goto" statement test', function () {
                         'break break_my_label;' +
                     '}' +
                     'if (!goingToLabel_my_label) {' +
-                        'stdout.write(tools.valueFactory.createInteger(4).coerceToString().getNative());' +
+                        'echo(createInteger(4));' +
                     '}' +
                 '}' +
                 'goingToLabel_my_label = false;' +
-            '} while (scope.getVariable("myCondition").getValue().coerceToBoolean().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            '} while (loop(0, getVariable("myCondition")));' +
             '});'
         );
     });
@@ -636,15 +628,14 @@ describe('Transpiler "goto" statement test', function () {
         // TODO: Improve this - unused labels _could_ just be completely removed.
         //       Perhaps one to solve with a compiler pass once we have an IR stage?
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo;' +
             'var goingToLabel_my_unused_label = false;' +
             'if (!goingToLabel_my_unused_label) {' +
-                'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                'echo(createString("first"));' +
             '}' +
             'goingToLabel_my_unused_label = false;' +
-            'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
-            'return tools.valueFactory.createNull();' +
+            'echo(createString("second"));' +
             '});'
         );
     });
@@ -690,12 +681,12 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo, getVariable = core.getVariable, if_ = core.if_;' +
             'var goingToLabel_my_label = false;' +
             'break_my_label: {' +
                 'if (!goingToLabel_my_label) {' +
-                    'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                    'echo(createString("first"));' +
                 '}' +
                 'if (!goingToLabel_my_label) {' +
                     'goingToLabel_my_label = true; ' +
@@ -704,13 +695,12 @@ describe('Transpiler "goto" statement test', function () {
             '}' +
             // The if statement's condition must allow execution to pass if we need to jump to a label
             // that is inside its consequent clause's body
-            'if (goingToLabel_my_label || (scope.getVariable("myCondition").getValue().coerceToBoolean().getNative())) {' +
+            'if (goingToLabel_my_label || (if_(getVariable("myCondition")))) {' +
                 'if (!goingToLabel_my_label) {' +
-                    'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
+                    'echo(createString("second"));' +
                 '}' +
                 'goingToLabel_my_label = false;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -766,12 +756,12 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo, getVariable = core.getVariable, if_ = core.if_;' +
             'var goingToLabel_my_label = false;' +
             'break_my_label: {' +
                 'if (!goingToLabel_my_label) {' +
-                    'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                    'echo(createString("first"));' +
                 '}' +
                 'if (!goingToLabel_my_label) {' +
                     'goingToLabel_my_label = true; ' +
@@ -780,15 +770,14 @@ describe('Transpiler "goto" statement test', function () {
             '}' +
             // The if statement's condition must _not_ allow execution to pass if we need to jump to a label
             // that is inside its alternate clause's body
-            'if (scope.getVariable("myCondition").getValue().coerceToBoolean().getNative()) {' +
-                'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
+            'if (if_(getVariable("myCondition"))) {' +
+                'echo(createString("second"));' +
             '} else {' +
                 'if (!goingToLabel_my_label) {' +
-                    'stdout.write(tools.valueFactory.createString("third").coerceToString().getNative());' +
+                    'echo(createString("third"));' +
                 '}' +
                 'goingToLabel_my_label = false;' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -840,12 +829,12 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo, getVariable = core.getVariable, if_ = core.if_;' +
             'var goingToLabel_my_label = false;' +
             'break_my_label: {' +
                 'if (!goingToLabel_my_label) {' +
-                    'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                    'echo(createString("first"));' +
                 '}' +
                 'if (!goingToLabel_my_label) {' +
                     'goingToLabel_my_label = true; ' +
@@ -854,15 +843,14 @@ describe('Transpiler "goto" statement test', function () {
             '}' +
             // The if statement's condition must allow execution to pass if we need to jump to a label
             // that is inside its consequent clause's body
-            'if (goingToLabel_my_label || (scope.getVariable("myCondition").getValue().coerceToBoolean().getNative())) {' +
+            'if (goingToLabel_my_label || (if_(getVariable("myCondition")))) {' +
                 'continue_my_label: do {' +
                     'goingToLabel_my_label = false;' +
-                    'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
+                    'echo(createString("second"));' +
                     'goingToLabel_my_label = true; ' +
                     'continue continue_my_label;' +
                 '} while (goingToLabel_my_label);' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -909,10 +897,9 @@ describe('Transpiler "goto" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunc", function _myFunc() {' +
-                'var scope = this;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, defineFunction = core.defineFunction, echo = core.echo;' +
+            'defineFunction("myFunc", function _myFunc() {' +
                 'var goingToLabel_my_label = false;' +
                 'break_my_label: {' +
                     'if (!goingToLabel_my_label) {' +
@@ -920,13 +907,12 @@ describe('Transpiler "goto" statement test', function () {
                         'break break_my_label;' +
                     '}' +
                     'if (!goingToLabel_my_label) {' +
-                        'stdout.write(tools.valueFactory.createString("first").coerceToString().getNative());' +
+                        'echo(createString("first"));' +
                     '}' +
                 '}' +
                 'goingToLabel_my_label = false;' +
-                'stdout.write(tools.valueFactory.createString("second").coerceToString().getNative());' +
-            '}, namespaceScope);' +
-            'return tools.valueFactory.createNull();' +
+                'echo(createString("second"));' +
+            '});' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/gotoTest.js
+++ b/test/integration/transpiler/statements/gotoTest.js
@@ -917,6 +917,95 @@ describe('Transpiler "goto" statement test', function () {
         );
     });
 
+    it('should correctly transpile a goto to a label in a different case of the same switch', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_SWITCH_STATEMENT',
+                expression: {
+                    name: 'N_VARIABLE',
+                    variable: 'myVar'
+                },
+                cases: [{
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    body: [{
+                        name: 'N_LABEL_STATEMENT',
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
+                    }, {
+                        name: 'N_ECHO_STATEMENT',
+                        expressions: [{
+                            name: 'N_INTEGER',
+                            number: '4'
+                        }]
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }, {
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 27
+                    },
+                    body: [{
+                        name: 'N_ECHO_STATEMENT',
+                        expressions: [{
+                            name: 'N_INTEGER',
+                            number: '7'
+                        }]
+                    }, {
+                        name: 'N_GOTO_STATEMENT',
+                        label: {
+                            name: 'N_STRING',
+                            string: 'my_label'
+                        }
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+                'var createInteger = core.createInteger, echo = core.echo, getVariable = core.getVariable, switchCase = core.switchCase, switchOn = core.switchOn;' +
+                'var goingToLabel_my_label = false;' +
+                'var switchExpression_1 = switchOn(getVariable("myVar")), ' +
+                'switchMatched_1 = false;' +
+                'block_1: {' +
+                    'continue_my_label: do {' +
+                        // Note that this condition does not need to check goingToLabel_my_label -
+                        // jumps into or out of a switch are illegal, so a goto must originate from another case,
+                        // which will have set switchMatched_1 to true.
+                        'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(21))) {' +
+                            'switchMatched_1 = true;' +
+                            // Transpiled label statement - the label has been reached if we were jumping to it
+                            // with a goto, therefore we can clear the flag indicating we are mid-goto.
+                            'goingToLabel_my_label = false;' +
+                            'echo(createInteger(4));' +
+                            'break block_1;' +
+                        '}' +
+                        'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
+                            'switchMatched_1 = true;' +
+                            'echo(createInteger(7));' +
+                            // Perform the goto - jump back to the top of the labelled loop and then work down
+                            // to the position of the label (skipping code as required with if blocks).
+                            'goingToLabel_my_label = true; continue continue_my_label;' +
+                        '}' +
+                    '} while (goingToLabel_my_label);' +
+                '}' +
+            '});'
+        );
+    });
+
     it('should throw a fatal error when attempting to jump forwards into a while loop', function () {
         var ast = {
             name: 'N_PROGRAM',

--- a/test/integration/transpiler/statements/hoistingTest.js
+++ b/test/integration/transpiler/statements/hoistingTest.js
@@ -70,12 +70,12 @@ describe('Transpiler statement hoisting test', function () {
             'var createInteger = core.createInteger, defineClass = core.defineClass, defineFunction = core.defineFunction, defineInterface = core.defineInterface, getVariable = core.getVariable, setValue = core.setValue, useClass = core.useClass;' +
             // "Use" import statement
             'useClass("Your\\\\Class", "YourImportedClass");' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {' +
+            // Class declaration statement
+            'defineClass("MyClass", {' +
             'superClass: "YourImportedClass", ' +
             // TODO: Don't output these properties in this object literal when they are empty
             'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
-            '}());' +
+            // Function declaration statement
             'defineFunction("aFinalFunc", function _aFinalFunc() {});' +
             // Interface declaration statement
             'defineInterface("Thing", {' +

--- a/test/integration/transpiler/statements/hoistingTest.js
+++ b/test/integration/transpiler/statements/hoistingTest.js
@@ -58,17 +58,17 @@ describe('Transpiler statement hoisting test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespaceScope.use("Your\\\\Class", "YourImportedClass");' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, defineFunction = core.defineFunction, getVariable = core.getVariable, setValue = core.setValue, useClass = core.useClass;' +
+            'useClass("Your\\\\Class", "YourImportedClass");' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {' +
-            'superClass: namespaceScope.getClass("YourImportedClass"), ' +
-            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}}, namespaceScope);' +
+            'var currentClass = defineClass("MyClass", {' +
+            'superClass: "YourImportedClass", ' +
+            // TODO: Don't output these properties in this object literal when they are empty
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
             '}());' +
-            'namespace.defineFunction("aFinalFunc", function _aFinalFunc() {var scope = this;}, namespaceScope);' +
-            'scope.getVariable("myVar").setValue(tools.valueFactory.createInteger(21));' +
-            'return tools.valueFactory.createNull();' +
+            'defineFunction("aFinalFunc", function _aFinalFunc() {});' +
+            'setValue(getVariable("myVar"), createInteger(21));' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/hoistingTest.js
+++ b/test/integration/transpiler/statements/hoistingTest.js
@@ -58,8 +58,8 @@ describe('Transpiler statement hoisting test', function () {
                 name: 'N_INTERFACE_STATEMENT',
                 interfaceName: 'Thing',
                 extend: [
-                    'First\\SuperInterface',
-                    'Second\\SuperInterface'
+                    'First\\SuperClass',
+                    'Second\\SuperClass'
                 ],
                 members: []
             }]
@@ -68,21 +68,302 @@ describe('Transpiler statement hoisting test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createInteger = core.createInteger, defineClass = core.defineClass, defineFunction = core.defineFunction, defineInterface = core.defineInterface, getVariable = core.getVariable, setValue = core.setValue, useClass = core.useClass;' +
-            // "Use" import statement
+            // "Use" import statement.
             'useClass("Your\\\\Class", "YourImportedClass");' +
-            // Class declaration statement
+            // Function declaration statement.
+            'defineFunction("aFinalFunc", function _aFinalFunc() {});' +
+            // Interface declaration statement (hoisted above classes).
+            'defineInterface("Thing", {' +
+            'superClass: null, ' +
+            'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Class declaration statement.
             'defineClass("MyClass", {' +
             'superClass: "YourImportedClass", ' +
             // TODO: Don't output these properties in this object literal when they are empty
             'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
-            // Function declaration statement
-            'defineFunction("aFinalFunc", function _aFinalFunc() {});' +
-            // Interface declaration statement
-            'defineInterface("Thing", {' +
-            'superClass: null, ' +
-            'interfaces: ["First\\\\SuperInterface","Second\\\\SuperInterface"], ' +
-            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Expression statement ends up below all declarations.
             'setValue(getVariable("myVar"), createInteger(21));' +
+            '});'
+        );
+    });
+
+    it('should sort to allow a class extending one defined after it', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CLASS_STATEMENT',
+                className: 'ChildClass',
+                extend: 'ParentClass',
+                members: []
+            }, {
+                name: 'N_CLASS_STATEMENT',
+                className: 'ParentClass',
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass;' +
+            // Parent class declaration statement. Note that it has been sorted
+            // above the child class so that it is defined first.
+            'defineClass("ParentClass", {' +
+            'superClass: null, ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Child class declaration statement.
+            'defineClass("ChildClass", {' +
+            'superClass: "ParentClass", ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            '});'
+        );
+    });
+
+    it('should sort parent->child->grandparent class declarations as grandparent->parent->child', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CLASS_STATEMENT',
+                className: 'ParentClass',
+                extend: 'GrandparentClass',
+                members: []
+            }, {
+                name: 'N_CLASS_STATEMENT',
+                className: 'ChildClass',
+                extend: 'ParentClass',
+                members: []
+            }, {
+                name: 'N_CLASS_STATEMENT',
+                className: 'GrandparentClass',
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass;' +
+            // Grandparent class declaration statement. Note that it has been sorted
+            // above both the parent and child classes so that it is defined first.
+            'defineClass("GrandparentClass", {' +
+            'superClass: null, ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Parent class declaration statement. Note that it has been sorted
+            // above the child class so that it is defined first.
+            'defineClass("ParentClass", {' +
+            'superClass: "GrandparentClass", ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Child class declaration statement.
+            'defineClass("ChildClass", {' +
+            'superClass: "ParentClass", ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            '});'
+        );
+    });
+
+    it('should sort child->parent class declarations as parent->child when ->grandparent class is referenced but missing', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CLASS_STATEMENT',
+                className: 'ChildClass',
+                extend: 'ParentClass',
+                members: []
+            }, {
+                name: 'N_CLASS_STATEMENT',
+                className: 'ParentClass',
+                extend: 'GrandparentClass',
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass;' +
+
+            // Note that grandparent class declaration statement is missing.
+
+            // Parent class declaration statement. Note that it has been sorted
+            // above the child class so that it is defined first.
+            'defineClass("ParentClass", {' +
+            'superClass: "GrandparentClass", ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Child class declaration statement.
+            'defineClass("ChildClass", {' +
+            'superClass: "ParentClass", ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            '});'
+        );
+    });
+
+    it('should not hoist a "use" statement if after a class', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_CLASS_STATEMENT',
+                className: 'MyClass',
+                extend: 'YourImportedClass',
+                members: []
+            }, {
+                name: 'N_USE_STATEMENT',
+                uses: [{
+                    source: 'Your\\Class',
+                    alias: 'YourImportedClass'
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineClass = core.defineClass, useClass = core.useClass;' +
+            // Class declaration statement.
+            'defineClass("MyClass", {' +
+            'superClass: "YourImportedClass", ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // "Use" import statement.
+            'useClass("Your\\\\Class", "YourImportedClass");' +
+            '});'
+        );
+    });
+
+    it('should sort to allow an interface extending one defined after it', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'ChildInterface',
+                extend: ['ParentInterface'],
+                members: []
+            }, {
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'ParentInterface',
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineInterface = core.defineInterface;' +
+            // Parent interface declaration statement. Note that it has been sorted
+            // above the child interface so that it is defined first.
+            'defineInterface("ParentInterface", {' +
+            'superClass: null, ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Child interface declaration statement.
+            'defineInterface("ChildInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["ParentInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            '});'
+        );
+    });
+
+    it('should sort parent->child->grandparent interface declarations as grandparent->parent->child', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'ParentInterface',
+                extend: ['GrandparentInterface'],
+                members: []
+            }, {
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'ChildInterface',
+                extend: ['ParentInterface'],
+                members: []
+            }, {
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'GrandparentInterface',
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineInterface = core.defineInterface;' +
+            // Grandparent interface declaration statement. Note that it has been sorted
+            // above both the parent and child interfaces so that it is defined first.
+            'defineInterface("GrandparentInterface", {' +
+            'superClass: null, ' +
+            'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Parent interface declaration statement. Note that it has been sorted
+            // above the child interface so that it is defined first.
+            'defineInterface("ParentInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["GrandparentInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Child interface declaration statement.
+            'defineInterface("ChildInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["ParentInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            '});'
+        );
+    });
+
+    it('should sort child->parent interface declarations as parent->child when ->grandparent interface is referenced but missing', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'ChildInterface',
+                extend: ['ParentInterface'],
+                members: []
+            }, {
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'ParentInterface',
+                extend: ['GrandparentInterface'],
+                members: []
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineInterface = core.defineInterface;' +
+
+            // Note that grandparent interface declaration statement is missing.
+
+            // Parent interface declaration statement. Note that it has been sorted
+            // above the child interface so that it is defined first.
+            'defineInterface("ParentInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["GrandparentInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // Child interface declaration statement.
+            'defineInterface("ChildInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["ParentInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            '});'
+        );
+    });
+
+    it('should not hoist a "use" statement if after a interface', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'MyInterface',
+                extend: ['YourImportedInterface'],
+                members: []
+            }, {
+                name: 'N_USE_STATEMENT',
+                uses: [{
+                    source: 'Your\\Interface',
+                    alias: 'YourImportedInterface'
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var defineInterface = core.defineInterface, useClass = core.useClass;' +
+            // Interface declaration statement.
+            'defineInterface("MyInterface", {' +
+            'superClass: null, ' +
+            'interfaces: ["YourImportedInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
+            // "Use" import statement.
+            'useClass("Your\\\\Interface", "YourImportedInterface");' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/hoistingTest.js
+++ b/test/integration/transpiler/statements/hoistingTest.js
@@ -13,7 +13,7 @@ var expect = require('chai').expect,
     phpToJS = require('../../../..');
 
 describe('Transpiler statement hoisting test', function () {
-    it('should correctly transpile a use followed by assignment, class and function statements', function () {
+    it('should correctly transpile a use followed by assignment, class, interface and function statements', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -54,12 +54,21 @@ describe('Transpiler statement hoisting test', function () {
                     name: 'N_COMPOUND_STATEMENT',
                     statements: []
                 }
+            }, {
+                name: 'N_INTERFACE_STATEMENT',
+                interfaceName: 'Thing',
+                extend: [
+                    'First\\SuperInterface',
+                    'Second\\SuperInterface'
+                ],
+                members: []
             }]
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
-            'var createInteger = core.createInteger, defineClass = core.defineClass, defineFunction = core.defineFunction, getVariable = core.getVariable, setValue = core.setValue, useClass = core.useClass;' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, defineFunction = core.defineFunction, defineInterface = core.defineInterface, getVariable = core.getVariable, setValue = core.setValue, useClass = core.useClass;' +
+            // "Use" import statement
             'useClass("Your\\\\Class", "YourImportedClass");' +
             '(function () {' +
             'var currentClass = defineClass("MyClass", {' +
@@ -68,6 +77,11 @@ describe('Transpiler statement hoisting test', function () {
             'interfaces: [], staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
             '}());' +
             'defineFunction("aFinalFunc", function _aFinalFunc() {});' +
+            // Interface declaration statement
+            'defineInterface("Thing", {' +
+            'superClass: null, ' +
+            'interfaces: ["First\\\\SuperInterface","Second\\\\SuperInterface"], ' +
+            'staticProperties: {}, properties: {}, methods: {}, constants: {}});' +
             'setValue(getVariable("myVar"), createInteger(21));' +
             '});'
         );

--- a/test/integration/transpiler/statements/ifStatementTest.js
+++ b/test/integration/transpiler/statements/ifStatementTest.js
@@ -24,12 +24,10 @@ describe('Transpiler if statement test', function () {
                         name: 'N_VARIABLE',
                         variable: 'myObject'
                     },
-                    properties: [{
-                        property: {
-                            name: 'N_STRING',
-                            string: 'myProp'
-                        }
-                    }]
+                    property: {
+                        name: 'N_STRING',
+                        string: 'myProp'
+                    }
                 },
                 consequentStatement: {
                     name: 'N_COMPOUND_STATEMENT',
@@ -39,10 +37,9 @@ describe('Transpiler if statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'if (scope.getVariable("myObject").getValue().getInstancePropertyByName(tools.valueFactory.createBarewordString("myProp")).getValue().coerceToBoolean().getNative()) {}' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var getInstanceProperty = core.getInstanceProperty, getVariable = core.getVariable, if_ = core.if_;' +
+            'if (if_(getInstanceProperty(getVariable("myObject"), "myProp"))) {}' +
             '}'
         );
     });
@@ -72,12 +69,10 @@ describe('Transpiler if statement test', function () {
                                         name: 'N_VARIABLE',
                                         variable: 'myObject'
                                     },
-                                    properties: [{
-                                        property: {
-                                            name: 'N_STRING',
-                                            string: 'myProp'
-                                        }
-                                    }]
+                                    property: {
+                                        name: 'N_STRING',
+                                        string: 'myProp'
+                                    }
                                 },
                                 consequentStatement: {
                                     name: 'N_COMPOUND_STATEMENT',
@@ -91,14 +86,14 @@ describe('Transpiler if statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            '(tools.valueFactory.createBarewordString("myFunc").call([' +
-            'tools.createClosure(function () {var scope = this;' +
-            'if (scope.getVariable("myObject").getValue().getInstancePropertyByName(tools.valueFactory.createBarewordString("myProp")).getValue().coerceToBoolean().getNative()) {}' +
-            '}, scope, namespaceScope)' +
-            '], namespaceScope) || tools.valueFactory.createNull());' +
-            'return tools.valueFactory.createNull();}'
+            'function (core) {' +
+            'var callFunction = core.callFunction, createClosure = core.createClosure, getInstanceProperty = core.getInstanceProperty, getVariable = core.getVariable, if_ = core.if_;' +
+            'callFunction("myFunc", [' +
+            'createClosure(function () {' +
+            'if (if_(getInstanceProperty(getVariable("myObject"), "myProp"))) {}' +
+            '})' +
+            ']);' +
+            '}'
         );
     });
 
@@ -143,14 +138,13 @@ describe('Transpiler if statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'if (tools.valueFactory.createBoolean(true).coerceToBoolean().getNative()) {' +
-            '(tools.valueFactory.createBarewordString("firstFunc").call([], namespaceScope) || tools.valueFactory.createNull());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var callFunction = core.callFunction, if_ = core.if_, trueValue = core.trueValue;' +
+            'if (if_(trueValue)) {' +
+            'callFunction("firstFunc");' +
             '} else {' +
-            '(tools.valueFactory.createBarewordString("secondFunc").call([], namespaceScope) || tools.valueFactory.createNull());' +
+            'callFunction("secondFunc");' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });
@@ -222,18 +216,35 @@ describe('Transpiler if statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'if (tools.valueFactory.createBoolean(' +
-            'tools.valueFactory.createInteger(1).isIdenticalTo(' +
-            'tools.valueFactory.createInteger(2)).coerceToBoolean().getNative() || (' +
-            'tools.valueFactory.createBoolean(tools.valueFactory.createInteger(3).isIdenticalTo(' +
-            'tools.valueFactory.createInteger(4)).coerceToBoolean().getNative() || (' +
-            'tools.valueFactory.createInteger(5).isIdenticalTo(tools.valueFactory.createInteger(6)' +
-            ').coerceToBoolean().getNative())).coerceToBoolean().getNative()' +
-            ')' +
-            ').coerceToBoolean().getNative()) {}' +
-            'return tools.valueFactory.createNull();' +
+            'function (core) {' +
+            'var createBoolean = core.createBoolean, createInteger = core.createInteger, if_ = core.if_, isIdentical = core.isIdentical, logicalTerm = core.logicalTerm;' +
+            'if (' +
+                'if_(' +
+                    'createBoolean(' +
+                        'logicalTerm(' +
+                            'isIdentical(' +
+                                'createInteger(1), ' +
+                                'createInteger(2)' +
+                            ')' +
+                        ') || logicalTerm(' +
+                            'createBoolean(' +
+                                'logicalTerm(' +
+                                    'isIdentical(' +
+                                        'createInteger(3), ' +
+                                        'createInteger(4)' +
+                                    ')' +
+                                ') || logicalTerm(' +
+                                    'isIdentical(' +
+                                        'createInteger(5), ' +
+                                        'createInteger(6)' +
+                                    ')' +
+                                ')' +
+                            ')' +
+                        ')' +
+                    ')' +
+                ')' +
+            ') ' +
+            '{}' +
             '}'
         );
     });

--- a/test/integration/transpiler/statements/inlineHtmlTest.js
+++ b/test/integration/transpiler/statements/inlineHtmlTest.js
@@ -1,0 +1,32 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler inline HTML statement test', function () {
+    it('should correctly transpile in default (async) mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_INLINE_HTML_STATEMENT',
+                html: '<p>My inline HTML</p>'
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var printRaw = core.printRaw;' +
+            'printRaw("<p>My inline HTML</p>");' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/statements/interfaceTest.js
+++ b/test/integration/transpiler/statements/interfaceTest.js
@@ -80,10 +80,10 @@ describe('Transpiler interface statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, defineInterface = core.defineInterface;' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("Thing", {' +
+            'var currentClass = defineInterface("Thing", {' +
             'superClass: null, ' +
             'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
             'staticProperties: {}, ' +
@@ -93,12 +93,11 @@ describe('Transpiler interface statement test', function () {
             '"doSomethingElse": {isStatic: false, abstract: true}' +
             '}, ' +
             'constants: {' +
-            '"SHAPE_ONE": function () { return tools.valueFactory.createString("sphere"); }, ' +
-            '"SHAPE_TWO": function () { return tools.valueFactory.createString("circle"); }' +
+            '"SHAPE_ONE": function () { return createString("sphere"); }, ' +
+            '"SHAPE_TWO": function () { return createString("circle"); }' +
             '}' +
-            '}, namespaceScope);' +
+            '});' +
             '}());' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/interfaceTest.js
+++ b/test/integration/transpiler/statements/interfaceTest.js
@@ -82,8 +82,7 @@ describe('Transpiler interface statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var createString = core.createString, defineInterface = core.defineInterface;' +
-            '(function () {' +
-            'var currentClass = defineInterface("Thing", {' +
+            'defineInterface("Thing", {' +
             'superClass: null, ' +
             'interfaces: ["First\\\\SuperClass","Second\\\\SuperClass"], ' +
             'staticProperties: {}, ' +
@@ -93,11 +92,11 @@ describe('Transpiler interface statement test', function () {
             '"doSomethingElse": {isStatic: false, abstract: true}' +
             '}, ' +
             'constants: {' +
-            '"SHAPE_ONE": function () { return createString("sphere"); }, ' +
-            '"SHAPE_TWO": function () { return createString("circle"); }' +
+            // TODO: Prevent unnecessary currentClass parameter from being output when not referenced
+            '"SHAPE_ONE": function (currentClass) { return createString("sphere"); }, ' +
+            '"SHAPE_TWO": function (currentClass) { return createString("circle"); }' +
             '}' +
             '});' +
-            '}());' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/namespaceTest.js
+++ b/test/integration/transpiler/statements/namespaceTest.js
@@ -214,14 +214,13 @@ describe('Transpiler namespace statement test', function () {
 
             // Second namespace scope
             'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\Space");' +
-            '(function () {' +
-            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
             'method: function _getClass() {' +
             'return getNamespaceName();' +
             '}}' +
-            '}, constants: {}});}());' +
+            '}, constants: {}});' +
             '}'
         );
     });

--- a/test/integration/transpiler/statements/namespaceTest.js
+++ b/test/integration/transpiler/statements/namespaceTest.js
@@ -13,10 +13,162 @@ var expect = require('chai').expect,
     phpToJS = require('../../../..');
 
 describe('Transpiler namespace statement test', function () {
+    it('should correctly transpile two adjacent namespace statements with a return in the second', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\FirstSpace',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_PRINT_EXPRESSION',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 1234
+                        }
+                    }
+                }]
+            }, {
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\SecondSpace',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 9876
+                    }
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, print = core.print, useDescendantNamespaceScope = core.useDescendantNamespaceScope;' +
+
+            // First namespace scope
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\FirstSpace");' +
+            'print(createInteger(1234));' +
+
+            // Second namespace scope
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\SecondSpace");' +
+            'return createInteger(9876);' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile two adjacent namespace statements where first is for the global namespace', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: '',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_PRINT_EXPRESSION',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 1234
+                        }
+                    }
+                }]
+            }, {
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\SubSpace',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_PRINT_EXPRESSION',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 6543
+                        }
+                    }
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, print = core.print, useDescendantNamespaceScope = core.useDescendantNamespaceScope, useGlobalNamespaceScope = core.useGlobalNamespaceScope;' +
+
+            // First namespace scope
+            'useGlobalNamespaceScope();' +
+            'print(createInteger(1234));' +
+
+            // Second namespace scope
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\SubSpace");' +
+            'print(createInteger(6543));' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile two adjacent namespace statements where second is for the global namespace', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\SubSpace',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_PRINT_EXPRESSION',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 6543
+                        }
+                    }
+                }]
+            }, {
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: '',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_PRINT_EXPRESSION',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 1234
+                        }
+                    }
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, print = core.print, useDescendantNamespaceScope = core.useDescendantNamespaceScope, useGlobalNamespaceScope = core.useGlobalNamespaceScope;' +
+
+            // First namespace scope
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\SubSpace");' +
+            'print(createInteger(6543));' +
+
+            // Second namespace scope
+            'useGlobalNamespaceScope();' +
+            'print(createInteger(1234));' +
+            '});'
+        );
+    });
+
     it('should correctly transpile a return statement inside class method inside namespace', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [
+                {
+                    name: 'N_NAMESPACE_STATEMENT',
+                    namespace: 'Your\\Space',
+                    statements: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_PRINT_EXPRESSION',
+                            operand: {
+                                name: 'N_INTEGER',
+                                number: 1234
+                            }
+                        }
+                    }]
+                },
                 {
                     name: 'N_NAMESPACE_STATEMENT',
                     namespace: 'This\\Is\\My\\Space',
@@ -53,20 +205,24 @@ describe('Transpiler namespace statement test', function () {
         };
 
         expect(phpToJS.transpile(ast, {bare: true})).to.equal(
-            'function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'if (namespaceResult = (function (globalNamespace) {' +
-            'var namespace = globalNamespace.getDescendant("This\\\\Is\\\\My\\\\Space"), namespaceScope = tools.createNamespaceScope(namespace);' +
+            'function (core) {' +
+            'var createInteger = core.createInteger, defineClass = core.defineClass, getNamespaceName = core.getNamespaceName, print = core.print, useDescendantNamespaceScope = core.useDescendantNamespaceScope;' +
+
+            // First namespace scope
+            'useDescendantNamespaceScope("Your\\\\Space");' +
+            'print(createInteger(1234));' +
+
+            // Second namespace scope
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\Space");' +
             '(function () {' +
-            'var currentClass = namespace.defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
+            'var currentClass = defineClass("MyClass", {superClass: null, interfaces: [], staticProperties: {}, properties: {}, methods: {' +
             '"getClass": {' +
             'isStatic: false, ' +
-            'method: function _getClass() {var scope = this;' +
-            'return namespaceScope.getNamespaceName();' +
+            'method: function _getClass() {' +
+            'return getNamespaceName();' +
             '}}' +
-            '}, constants: {}}, namespaceScope);}());' +
-            '}(namespace))) { return namespaceResult; }' +
-            'return tools.valueFactory.createNull();}'
+            '}, constants: {}});}());' +
+            '}'
         );
     });
 });

--- a/test/integration/transpiler/statements/staticTest.js
+++ b/test/integration/transpiler/statements/staticTest.js
@@ -57,17 +57,15 @@ describe('Transpiler static variable scope statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'namespace.defineFunction("myFunc", function _myFunc($myArg) {' +
-            'var scope = this;' +
-            'scope.getVariable("myArg").setValue($myArg.getValue());' +
-            'scope.importStatic("firstVar");' +
-            'scope.importStatic("secondVar", tools.valueFactory.createInteger(101));' +
-            '}, namespaceScope, [' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, defineFunction = core.defineFunction, getVariable = core.getVariable, importStatic = core.importStatic, setValue = core.setValue;' +
+            'defineFunction("myFunc", function _myFunc($myArg) {' +
+            'setValue(getVariable("myArg"), $myArg);' +
+            'importStatic("firstVar");' +
+            'importStatic("secondVar", createInteger(101));' +
+            '}, [' +
             '{"type":"callable","name":"myArg"}' +
             ']);' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/switchTest.js
+++ b/test/integration/transpiler/statements/switchTest.js
@@ -306,7 +306,7 @@ describe('Transpiler "switch" statement test', function () {
 
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
-            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchDefault = core.switchDefault, switchOn = core.switchOn;' +
             'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
             'switchMatched_1 = false;' +
             'block_1: while (true) {' +
@@ -315,7 +315,7 @@ describe('Transpiler "switch" statement test', function () {
             'setValue(getVariable("a"), createInteger(7));' +
             'break block_1;' +
             '}' +
-            'if (switchMatched_1 || switchExpression_1 === null) {' +
+            'if (switchMatched_1 || switchDefault(switchExpression_1)) {' +
             'switchMatched_1 = true;' +
             'setValue(getVariable("a"), createInteger(8));' +
             '}' +

--- a/test/integration/transpiler/statements/switchTest.js
+++ b/test/integration/transpiler/statements/switchTest.js
@@ -85,22 +85,21 @@ describe('Transpiler "switch" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
             'block_1: {' +
-            'var switchExpression_1 = tools.valueFactory.createInteger(21).add(tools.valueFactory.createInteger(6)), ' +
+            'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
             'switchMatched_1 = false;' +
-            'if (switchMatched_1 || switchExpression_1.isEqualTo(tools.valueFactory.createInteger(27)).getNative()) {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
             'switchMatched_1 = true; ' +
-            'scope.getVariable("a").setValue(tools.valueFactory.createInteger(7));' +
+            'setValue(getVariable("a"), createInteger(7));' +
             'break block_1;' +
             '}' +
             'if (!switchMatched_1) {' +
             'switchMatched_1 = true; ' +
-            'scope.getVariable("a").setValue(tools.valueFactory.createInteger(8));' +
+            'setValue(getVariable("a"), createInteger(8));' +
             '}' +
             '}' +
-            'return tools.valueFactory.createNull();' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/switchTest.js
+++ b/test/integration/transpiler/statements/switchTest.js
@@ -13,7 +13,109 @@ var expect = require('chai').expect,
     phpToJS = require('../../../..');
 
 describe('Transpiler "switch" statement test', function () {
-    it('should correctly transpile a switch with two cases and default in default (async) mode', function () {
+    it('should correctly transpile a switch with two cases and no default', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_SWITCH_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    right: [{
+                        operator: '+',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 6
+                        }
+                    }]
+                },
+                cases: [{
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 27
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '7'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }, {
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 101
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '10'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
+            'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
+            'switchMatched_1 = false;' +
+            'block_1: {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(7));' +
+            'break block_1;' +
+            '}' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(101))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(10));' +
+            'break block_1;' +
+            '}' +
+            '}' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a switch with one case and default with default as last', function () {
         var ast = {
             name: 'N_PROGRAM',
             statements: [{
@@ -87,18 +189,142 @@ describe('Transpiler "switch" statement test', function () {
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
             'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
-            'block_1: {' +
             'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
             'switchMatched_1 = false;' +
+            'block_1: {' +
             'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'setValue(getVariable("a"), createInteger(7));' +
             'break block_1;' +
             '}' +
-            'if (!switchMatched_1) {' +
-            'switchMatched_1 = true; ' +
+            'switchMatched_1 = true;' +
             'setValue(getVariable("a"), createInteger(8));' +
             '}' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a switch with two cases and default with default as second', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_SWITCH_STATEMENT',
+                expression: {
+                    name: 'N_EXPRESSION',
+                    left: {
+                        name: 'N_INTEGER',
+                        number: 21
+                    },
+                    right: [{
+                        operator: '+',
+                        operand: {
+                            name: 'N_INTEGER',
+                            number: 6
+                        }
+                    }]
+                },
+                cases: [{
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 101
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '7'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }, {
+                    name: 'N_DEFAULT_CASE',
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '8'
+                                }
+                            }]
+                        }
+                    }]
+                }, {
+                    name: 'N_CASE',
+                    expression: {
+                        name: 'N_INTEGER',
+                        number: 27
+                    },
+                    body: [{
+                        name: 'N_EXPRESSION_STATEMENT',
+                        expression: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_VARIABLE',
+                                variable: 'a'
+                            },
+                            right: [{
+                                operator: '=',
+                                operand: {
+                                    name: 'N_INTEGER',
+                                    number: '1001'
+                                }
+                            }]
+                        }
+                    }, {
+                        name: 'N_BREAK_STATEMENT',
+                        levels: {
+                            name: 'N_INTEGER',
+                            number: '1'
+                        }
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var add = core.add, createInteger = core.createInteger, getVariable = core.getVariable, setValue = core.setValue, switchCase = core.switchCase, switchOn = core.switchOn;' +
+            'var switchExpression_1 = switchOn(add(createInteger(21), createInteger(6))), ' +
+            'switchMatched_1 = false;' +
+            'block_1: while (true) {' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(101))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(7));' +
+            'break block_1;' +
+            '}' +
+            'if (switchMatched_1 || switchExpression_1 === null) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(8));' +
+            '}' +
+            'if (switchMatched_1 || switchCase(switchExpression_1, createInteger(27))) {' +
+            'switchMatched_1 = true;' +
+            'setValue(getVariable("a"), createInteger(1001));' +
+            'break block_1;' +
+            '}' +
+            'if (switchMatched_1) {break;} else {switchExpression_1 = null;}' +
             '}' +
             '});'
         );

--- a/test/integration/transpiler/statements/throwTest.js
+++ b/test/integration/transpiler/statements/throwTest.js
@@ -27,8 +27,8 @@ describe('Transpiler throw statement test', function () {
 
         expect(phpToJS.transpile(ast)).to.equal(
             'require(\'phpruntime\').compile(function (core) {' +
-            'var getVariable = core.getVariable;' +
-            'throw getVariable("myError");' +
+            'var getVariable = core.getVariable, throw_ = core.throw_;' +
+            'throw_(getVariable("myError"));' +
             '});'
         );
     });

--- a/test/integration/transpiler/statements/throwTest.js
+++ b/test/integration/transpiler/statements/throwTest.js
@@ -1,0 +1,35 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler throw statement test', function () {
+    it('should correctly transpile a throw of variable value in default (async) mode', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_THROW_STATEMENT',
+                expression: {
+                    name: 'N_VARIABLE',
+                    variable: 'myError'
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var getVariable = core.getVariable;' +
+            'throw getVariable("myError");' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/statements/useStatementTest.js
+++ b/test/integration/transpiler/statements/useStatementTest.js
@@ -1,0 +1,66 @@
+/*
+ * PHPToJS - PHP-to-JavaScript transpiler
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phptojs
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptojs/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpToJS = require('../../../..');
+
+describe('Transpiler use statement test', function () {
+    it('should correctly transpile a use statement with no alias inside namespace', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\Space',
+                statements: [{
+                    name: 'N_USE_STATEMENT',
+                    uses: [{
+                        source: 'My\\Imported\\MyClass'
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var useClass = core.useClass, useDescendantNamespaceScope = core.useDescendantNamespaceScope;' +
+
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\Space");' +
+            'useClass("My\\\\Imported\\\\MyClass");' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile a use statement with alias inside namespace', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_NAMESPACE_STATEMENT',
+                namespace: 'This\\Is\\My\\Space',
+                statements: [{
+                    name: 'N_USE_STATEMENT',
+                    uses: [{
+                        source: 'My\\Imported\\MyClass',
+                        alias: 'MyAlias'
+                    }]
+                }]
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var useClass = core.useClass, useDescendantNamespaceScope = core.useDescendantNamespaceScope;' +
+
+            'useDescendantNamespaceScope("This\\\\Is\\\\My\\\\Space");' +
+            'useClass("My\\\\Imported\\\\MyClass", "MyAlias");' +
+            '});'
+        );
+    });
+});

--- a/test/integration/transpiler/statements/whileTest.js
+++ b/test/integration/transpiler/statements/whileTest.js
@@ -46,14 +46,81 @@ describe('Transpiler "while" statement test', function () {
         };
 
         expect(phpToJS.transpile(ast)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'block_1: while (' +
-            'tools.valueFactory.createInteger(27).isGreaterThan(tools.valueFactory.createInteger(21)).coerceToBoolean().getNative()' +
-            ') {' +
-            'stdout.write(tools.valueFactory.createInteger(4).coerceToString().getNative());' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, echo = core.echo, isGreaterThan = core.isGreaterThan, loop = core.loop;' +
+            'block_1: while (loop(0, isGreaterThan(createInteger(27), createInteger(21)))) {' +
+            'echo(createInteger(4));' +
             '}' +
-            'return tools.valueFactory.createNull();' +
+            '});'
+        );
+    });
+
+    it('should correctly transpile multiple and nested while loops within a scope', function () {
+        var ast = {
+            name: 'N_PROGRAM',
+            statements: [{
+                name: 'N_WHILE_STATEMENT',
+                condition: {
+                    name: 'N_VARIABLE',
+                    variable: 'firstVar'
+                },
+                body: {
+                    name: 'N_COMPOUND_STATEMENT',
+                    statements: [{
+                        name: 'N_ECHO_STATEMENT',
+                        expressions: [{
+                            name: 'N_STRING_LITERAL',
+                            string: 'first'
+                        }]
+                    }, {
+                        name: 'N_WHILE_STATEMENT',
+                        condition: {
+                            name: 'N_VARIABLE',
+                            variable: 'secondVar'
+                        },
+                        body: {
+                            name: 'N_COMPOUND_STATEMENT',
+                            statements: [{
+                                name: 'N_ECHO_STATEMENT',
+                                expressions: [{
+                                    name: 'N_STRING_LITERAL',
+                                    string: 'second, nested'
+                                }]
+                            }]
+                        }
+                    }]
+                }
+            }, {
+                name: 'N_WHILE_STATEMENT',
+                condition: {
+                    name: 'N_VARIABLE',
+                    variable: 'thirdVar'
+                },
+                body: {
+                    name: 'N_COMPOUND_STATEMENT',
+                    statements: [{
+                        name: 'N_ECHO_STATEMENT',
+                        expressions: [{
+                            name: 'N_STRING_LITERAL',
+                            string: 'third'
+                        }]
+                    }]
+                }
+            }]
+        };
+
+        expect(phpToJS.transpile(ast)).to.equal(
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString, echo = core.echo, getVariable = core.getVariable, loop = core.loop;' +
+            'block_1: while (loop(0, getVariable("firstVar"))) {' +
+            'echo(createString("first"));' +
+            'block_2: while (loop(1, getVariable("secondVar"))) {' +
+            'echo(createString("second, nested"));' +
+            '}' +
+            '}' +
+            'block_1: while (loop(2, getVariable("thirdVar"))) {' +
+            'echo(createString("third"));' +
+            '}' +
             '});'
         );
     });

--- a/test/integration/transpiler/syncOptionTest.js
+++ b/test/integration/transpiler/syncOptionTest.js
@@ -26,10 +26,9 @@ describe('Transpiler "sync" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {sync: true})).to.equal(
-            'require(\'phpruntime/sync\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime/sync\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });
@@ -47,10 +46,9 @@ describe('Transpiler "sync" option test', function () {
         };
 
         expect(phpToJS.transpile(ast, {sync: false})).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'return tools.valueFactory.createString("my result");' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createString = core.createString;' +
+            'return createString("my result");' +
             '});'
         );
     });

--- a/test/integration/transpiler/tickTest.js
+++ b/test/integration/transpiler/tickTest.js
@@ -67,10 +67,9 @@ describe('Transpiler tick feature test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'tools.tick(2, 1, 3, 11);return tools.valueFactory.createInteger(4);' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, tick = core.tick;' +
+            'tick(2, 1, 3, 11);return createInteger(4);' +
             '});'
         );
     });
@@ -130,11 +129,10 @@ describe('Transpiler tick feature test', function () {
             };
 
         expect(phpToJS.transpile(ast, options)).to.equal(
-            'require(\'phpruntime\').compile(function (stdin, stdout, stderr, tools, namespace) {' +
-            'var namespaceScope = tools.topLevelNamespaceScope, namespaceResult, scope = tools.topLevelScope, currentClass = null;' +
-            'var line;tools.instrument(function () {return line;});' +
-            'line = 2;tools.tick(2, 1, 3, 11);return (line = 3, tools.valueFactory.createInteger(4));' +
-            'return tools.valueFactory.createNull();' +
+            'require(\'phpruntime\').compile(function (core) {' +
+            'var createInteger = core.createInteger, instrument = core.instrument, line, tick = core.tick;' +
+            'instrument(function () {return line;});' +
+            'line = 2;tick(2, 1, 3, 11);return (line = 3, createInteger(4));' +
             '});'
         );
     });


### PR DESCRIPTION
Large refactor to remove use of the Pausable library for async mode:

- Low-level operations are now defined in terms of opcodes (eg. an `add(...)` opcode for addition). Custom opcodes may be installed or existing opcodes overridden or hooked by addons/plugins.
- Async mode no longer involves an expensive on-the-fly transpile via Pausable - opcode execution is instead traced to allow future resumption after a pause.
- Default switch cases are now given the lowest priority, so they do not need to be below a matching non-default case.
- Fixes for `goto` inside switch cases.